### PR TITLE
feat: 랜덤 전시회 조회 API 구현 - #59

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,6 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { typeORMConfig } from "./config/typeorm.config";
+import { ExhibitionModule } from "./exhibition/exhibition.module";
 
 @Module({
-  imports: [],
+  imports: [
+      TypeOrmModule.forRoot(typeORMConfig),
+      ExhibitionModule,
+  ],
 })
 export class AppModule {}

--- a/server/src/category/category.entity.ts
+++ b/server/src/category/category.entity.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Exhibition } from '../exhibition/exhibition.entity';
 
 @Entity()
@@ -8,4 +8,7 @@ export class Category {
 
     @Column()
     name: string;
+
+    @ManyToOne(type => Exhibition, exhibition => exhibition.categories)
+    exhibition: Exhibition;
 }

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from "@nestjs/common";
+import { ExhibitionService } from "../service/exhibition.service";
+import { Exhibition } from "../exhibition.entity";
+
+@Controller('/exhibitions')
+export class ExhibitionController {
+    constructor(private exhibitionService: ExhibitionService) {}
+
+    @Get('/random')
+    getRandomExhibitions(): Promise<Exhibition[]> {
+        return this.exhibitionService.getRandomExhibitions();
+    }
+
+}

--- a/server/src/exhibition/exhibition.entity.ts
+++ b/server/src/exhibition/exhibition.entity.ts
@@ -26,7 +26,7 @@ export class Exhibition {
     thumbnailImage: string;
 
     @ManyToOne(type => User, user => user.exhibitionList)
-    user: User;
+    artist: User;
 
     @OneToMany(type => Category, category => category.exhibition)
     categories: Category[];

--- a/server/src/exhibition/exhibition.module.ts
+++ b/server/src/exhibition/exhibition.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ExhibitionController } from './controller/exhibition.controller';
+import { ExhibitionService } from './service/exhibition.service';
+import { ExhibitionRepository } from "./exhibition.repository";
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ ExhibitionRepository ]),
+    ],
+    controllers: [ ExhibitionController ],
+    providers: [ ExhibitionService ],
+})
+export class ExhibitionModule {}

--- a/server/src/exhibition/exhibition.repository.ts
+++ b/server/src/exhibition/exhibition.repository.ts
@@ -1,0 +1,13 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Exhibition } from "./exhibition.entity";
+
+@EntityRepository(Exhibition)
+export class ExhibitionRepository extends Repository<Exhibition> {
+
+    async getRandomExhibitions(): Promise<Exhibition[]> {
+        return await this.createQueryBuilder()
+            .orderBy('RAND()')
+            .limit(5)
+            .getMany();
+    }
+}

--- a/server/src/exhibition/service/exhibition.service.ts
+++ b/server/src/exhibition/service/exhibition.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ExhibitionRepository } from '../exhibition.repository';
+import { Exhibition } from "../exhibition.entity";
+
+@Injectable()
+export class ExhibitionService {
+    constructor(
+        @InjectRepository(ExhibitionRepository)
+        private exhibitionRepository: ExhibitionRepository
+    ) {}
+
+    getRandomExhibitions(): Promise<Exhibition[]> {
+        return this.exhibitionRepository.getRandomExhibitions();
+    }
+
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,4 +1,6 @@
 import { NestFactory } from '@nestjs/core';
+import * as dotenv from 'dotenv';
+dotenv.config();
 import { AppModule } from './app.module';
 
 async function bootstrap() {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -3,6 +3,11 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  const PORT = process.env.PORT || 3000;
+
+  app.setGlobalPrefix('/api');
+
+  await app.listen(PORT);
 }
+
 bootstrap();

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -46,6 +46,6 @@ export class User {
     @OneToMany(type => Exhibition, exhibition => exhibition.user)
     exhibitionList: Exhibition[];
 
-    @OneToMany(type => Auction, auction => auction.owner)
+    @OneToMany(type => Auction, auction => auction.seller)
     auctionList: Auction[];
 }

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -43,7 +43,7 @@ export class User {
     @OneToMany(type => ArtworkInBid, artworkInBid => artworkInBid.user)
     artworksInBid: Artwork[];
 
-    @OneToMany(type => Exhibition, exhibition => exhibition.user)
+    @OneToMany(type => Exhibition, exhibition => exhibition.artist)
     exhibitionList: Exhibition[];
 
     @OneToMany(type => Auction, auction => auction.seller)


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 랜덤 전시회 조회 API 구현
- global prefix 설정
- 전시회 엔티티 필드명 수정(user -> artist)

### 📑 구현한 내용 목록

- [x] 랜덤 전시회 조회 API 구현

### 🚧 주의 사항

### 🖥 스크린 샷

close #59