### PR TITLE
feat: 랜덤 auction artwork 조회 API 구현 - #58

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMConfig } from "./config/typeorm.config";
 import { ExhibitionModule } from "./exhibition/exhibition.module";
+import { ArtworkModule } from "./artwork/artwork.module";
 
 @Module({
   imports: [
       TypeOrmModule.forRoot(typeORMConfig),
       ExhibitionModule,
+      ArtworkModule
   ],
 })
 export class AppModule {}

--- a/server/src/artWork/artWork.module.ts
+++ b/server/src/artWork/artWork.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ArtworkRepository } from "./artwork.repository";
+import { ArtworkController } from "./controller/artwork.controller";
+import { ArtworkService } from "./service/artwork.service";
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ ArtworkRepository ]),
+    ],
+    controllers: [ ArtworkController ],
+    providers: [ ArtworkService ],
+})
+export class ArtworkModule {}

--- a/server/src/artWork/artWork.repository.ts
+++ b/server/src/artWork/artWork.repository.ts
@@ -1,0 +1,16 @@
+import { EntityRepository, Repository } from "typeorm";
+import { Artwork } from "./artwork.entity";
+import { ArtworkStatus } from "./artwork.status.enum";
+
+@EntityRepository(Artwork)
+export class ArtworkRepository extends Repository<Artwork> {
+
+    async getRandomAuctionArtworks(): Promise<Artwork[]> {
+        return await this.createQueryBuilder('artwork')
+            .where('artwork.status = :status', { status: ArtworkStatus.InBid })
+            .orderBy('RAND()')
+            .limit(3)
+            .getMany();
+    }
+
+}

--- a/server/src/artWork/controller/artWork.controller.ts
+++ b/server/src/artWork/controller/artWork.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from "@nestjs/common";
+import { ArtworkService } from "../service/artwork.service";
+import { Artwork } from "../artwork.entity";
+
+@Controller('/artworks')
+export class ArtworkController {
+    constructor(private artworkService: ArtworkService) {}
+
+    @Get('/random')
+    getRandomAuctionArtworks(): Promise<Artwork[]> {
+        return this.artworkService.getRandomAuctionArtworks();
+    }
+
+}

--- a/server/src/artWork/service/artWork.service.ts
+++ b/server/src/artWork/service/artWork.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ArtworkRepository } from "../artwork.repository";
+import { Artwork } from "../artwork.entity";
+
+@Injectable()
+export class ArtworkService {
+    constructor(
+        @InjectRepository(ArtworkRepository)
+        private artworkRepository: ArtworkRepository
+    ) {}
+
+    getRandomAuctionArtworks(): Promise<Artwork[]> {
+        return this.artworkRepository.getRandomAuctionArtworks();
+    }
+
+}

--- a/server/src/auction/auction.entity.ts
+++ b/server/src/auction/auction.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn} from 'typeorm';
 import { Artwork } from '../artwork/artwork.entity';
 import { User } from '../user/user.entity';
 import { AuctionHistory } from '../auctionHistory/auctionHistory.entity';
@@ -14,10 +14,11 @@ export class Auction {
     @Column({ type: 'datetime' })
     endAt: Date;
 
-    @ManyToOne(type => User, user => user.id)
+    @ManyToOne(type => User, user => user.auctionList)
     seller: User;
 
-    @OneToOne(type => Artwork, artwork => artwork.id)
+    @OneToOne(type => Artwork)
+    @JoinColumn()
     artwork: Artwork;
 
     @OneToMany(type => AuctionHistory, auctionHistory => auctionHistory.auction)


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 랜덤 auction artwork 조회 API 구현
- auction 엔티티 필드 수정
  - 일대일 연관관계 매핑에서 @JoinColumn 데코레이터를 사용하여 외래 키를 생성해주었다.

### 📑 구현한 내용 목록

- [x] 랜덤 auction artwork 조회 API 구현

### 🚧 주의 사항

### 🖥 스크린 샷

close #58 