### PR TITLE
feat: 색상 선택 관련 함수들 - #84

### DIFF
--- a/client/utils/getAvgColor.ts
+++ b/client/utils/getAvgColor.ts
@@ -1,0 +1,33 @@
+export const getAvgColor = (imgElem: StaticImageData) => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    const img = new Image();
+    img.src = imgElem.src;
+
+    const blockSize = 5;
+    const rgb = { r: 0, g: 0, b: 0 };
+    let count = 0;
+    let i = 0;
+    const height = imgElem.height;
+    const width = imgElem.width;
+    if (!context || !imgElem) {
+        return rgb;
+    }
+    img.onload = () => {
+        context.drawImage(img, 0, 0);
+        let data = context.getImageData(0, 0, width, height).data;
+        if (data) {
+            while ((i += blockSize * 4) < 70800) {
+                ++count;
+                rgb.r += data[i];
+                rgb.g += data[i + 1];
+                rgb.b += data[i + 2];
+            }
+
+            rgb.r = ~~(rgb.r / count);
+            rgb.g = ~~(rgb.g / count);
+            rgb.b = ~~(rgb.b / count);
+            return rgb;
+        }
+    };
+};

--- a/client/utils/isSelectBlack.ts
+++ b/client/utils/isSelectBlack.ts
@@ -1,0 +1,18 @@
+interface rgbType {
+    [key: string]: number;
+}
+
+const calculateL = (color: number) => {
+    color /= 255;
+    return color <= 0.03928 ? color / 12.92 : ((color + 0.055) / 1.055) ** 2.4;
+};
+export const isSelectBlack = (rgb: rgbType) => {
+    let L = 0;
+    for (const [key, color] of Object.entries(rgb)) {
+        if (key === 'r') L += 0.2126 * calculateL(color);
+        if (key === 'g') L += 0.7152 * calculateL(color);
+        if (key === 'b') L += 0.0722 * calculateL(color);
+        console.log('L:', L);
+    }
+    return (L + 0.05) / (0.0 + 0.05) > (1.0 + 0.05) / (L + 0.05);
+};


### PR DESCRIPTION
### 🔨 작업 내용 설명

메인 페이지에 글자가 배경에 겹치지 않도록 색상을 골라줘야 한다.
그래서 이미지의 평균 색상을 구하는 함수와 rgb값을 받아 흑인지 백인지 boolean을 리턴해주는 함수를 만들었다.

### 📑 구현한 내용 목록

- [x] get average color
- [x] select is black

### 🚧 주의 사항
고민 1. 만약 사진 위에 div를 씌워서 gradient를 넣어주거나 opacity를 넣어준다면 어떻게 계산할 것인가?

고민 2. 만약 배경 사진이 흑백 사진이라면 흑백 사진이 아닌 메인 컬러를 넣어주는게 낫지 않을까? 그렇다면 흑백 사진임을 판별하는 기준은 어떻게 해야할 것인가?

고민 3. 현재 가장 쉬운 방법은 각 사진의 rgb 값을 평균으로 받아내어 #000000 or #ffffff 에 가까운지 계산해주는 방법이다. 하지만 dominant 컬러를 뽑아내서 계산해야할지, dominant 컬러 기준으로 계산을 한다면 보색을 넣어줘야하는 것인지, dominant로 한다면 33%,33%,34%이면 이게 옳은 판단인지?

### 🖥 스크린 샷

close #84
