### PR TITLE
fix: 엔티티 및 Guard 코드 리팩토링 - #102

### DIFF
--- a/server/src/artwork/artwork.module.ts
+++ b/server/src/artwork/artwork.module.ts
@@ -6,11 +6,15 @@ import { ArtworkRepository } from './artwork.repository';
 import { ArtworkController } from './controller/artwork.controller';
 import { ArtworkService } from './service/artwork.service';
 import { UserRepository } from '../user/user.repository';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
     imports: [
         ImageModule,
         TypeOrmModule.forFeature([ ArtworkRepository, AuctionRepository, UserRepository ]),
+        JwtModule.register({
+            secret: process.env.JWT_SECRET_KEY,
+        }),
     ],
     controllers: [ArtworkController],
     providers: [ArtworkService],

--- a/server/src/auction/auction.entity.ts
+++ b/server/src/auction/auction.entity.ts
@@ -22,7 +22,10 @@ export class Auction {
     })
     startAt: Date;
 
-    @Column({ type: 'timestamp' })
+    @Column({
+        type: 'timestamp',
+        default: () => 'CURRENT_TIMESTAMP',
+    })
     endAt: Date;
 
     @ManyToOne(type => User, user => user.auctionList)

--- a/server/src/exhibition/exhibition.entity.ts
+++ b/server/src/exhibition/exhibition.entity.ts
@@ -16,10 +16,16 @@ export class Exhibition {
     @Column()
     description: string;
 
-    @Column({ type: 'datetime' })
+    @Column({
+        type: 'timestamp',
+        default: () => 'CURRENT_TIMESTAMP'
+    })
     startAt: Date;
 
-    @Column({ type: 'datetime' })
+    @Column({
+        type: 'timestamp',
+        default: () => 'CURRENT_TIMESTAMP'
+    })
     endAt: Date;
 
     @Column()

--- a/server/src/exhibition/exhibition.module.ts
+++ b/server/src/exhibition/exhibition.module.ts
@@ -3,10 +3,14 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { ExhibitionController } from './controller/exhibition.controller';
 import { ExhibitionService } from './service/exhibition.service';
 import { ExhibitionRepository } from "./exhibition.repository";
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([ ExhibitionRepository ]),
+        JwtModule.register({
+            secret: process.env.JWT_SECRET_KEY,
+        }),
     ],
     controllers: [ ExhibitionController ],
     providers: [ ExhibitionService ],

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -4,10 +4,14 @@ import { UserService } from './service/user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserRepository } from './user.repository';
 import { ArtworkRepository } from '../artwork/artwork.repository';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([ UserRepository, ArtworkRepository ]),
+        JwtModule.register({
+            secret: process.env.JWT_SECRET_KEY,
+        }),
     ],
     controllers: [ UserController ],
     providers: [ UserService ],


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 배포 환경 및 Guard 사용과 관련해 오류를 발생시키는 부분을 수정하였습니다.
- 엔티티의 Date 타입 필드에 대한 Column 타입을 timestamp로 통일해주었고, timestamp에 대해 default value를 설정해주지 않으면 `invalid default value for ...` 오류가 발생해 default value를 `CURRENT_TIMESTAMP`로 설정해주었습니다.
- 또한 Guard 사용 시 JwtService를 의존성 주입 받기 위해서는 각 Module에 `JwtModule.register`를 추가해주어야 하기 때문에 이 부분을 수정하였습니다.

### 📑 구현한 내용 목록

- [x] 엔티티 Date 타입 필드에 대한 Column 타입을 timestamp로 설정
- [x] Date 관련 엔티티 필드 default value 설정
- [x] Custom guard 사용을 위한 module 설정

### 🚧 주의 사항

### 🖥 스크린 샷

close #102 
