### PR TITLE
feat: 아트워크 post 페이지 api 연동 및 리팩토링 - #57

### DIFF
--- a/client/components/Artwork/ArtworkModal/index.tsx
+++ b/client/components/Artwork/ArtworkModal/index.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef } from 'react';
 import ArtworkFilter from './ArtworkFilter';
 import { Modal, Form, LightForm, ConfirmButton } from './style';
 
+const date = new Date();
+
 interface ArtworkModalProps {
     setData: React.Dispatch<{ [key: string]: string }>;
     position: string;
@@ -16,15 +18,27 @@ const ArtworkModal = ({
     const [checked, setChecked] = useState('artwork');
     const modalRef = useRef<HTMLDivElement | null>(null);
 
-    const descriptionInputRef = useRef<HTMLTextAreaElement | null>(null);
-    const yearInputRef = useRef<HTMLInputElement | null>(null);
-    const bidEndInputRef = useRef<HTMLInputElement | null>(null);
+    const [descriptionInput, setDescriptionInput] = useState('');
+    const [yearInput, setYearInput] = useState(date.getFullYear().toString());
+    const [bidEndInput, setBidEndIput] = useState('');
+
+    const onChangeDescription = (e: React.FormEvent) => {
+        setDescriptionInput((e.target as HTMLTextAreaElement).value);
+    };
+
+    const onChangeYear = (e: React.FormEvent) => {
+        setYearInput((e.target as HTMLInputElement).value);
+    };
+
+    const onChangeBidEnd = (e: React.FormEvent) => {
+        setBidEndIput((e.target as HTMLInputElement).value);
+    };
 
     const onClickConfirm = () => {
         setData({
-            description: descriptionInputRef.current!.value,
-            year: yearInputRef.current?.value || '',
-            bidEnd: bidEndInputRef.current?.value || '',
+            description: descriptionInput,
+            year: yearInput,
+            bidEnd: bidEndInput,
         });
         setPosition('-53vh');
     };
@@ -34,17 +48,29 @@ const ArtworkModal = ({
             <ArtworkFilter checked={checked} setChecked={setChecked} />
             <Form>
                 <span>Description</span>
-                <textarea cols={10} ref={descriptionInputRef} />
+                <textarea
+                    cols={10}
+                    value={descriptionInput}
+                    onChange={onChangeDescription}
+                />
             </Form>
             {checked === 'auction' && (
                 <>
                     <LightForm>
                         <span>Year</span>
-                        <input type="text" ref={yearInputRef} />
+                        <input
+                            type="text"
+                            value={yearInput}
+                            onChange={onChangeYear}
+                        />
                     </LightForm>
                     <LightForm>
                         <span>Bid End</span>
-                        <input type="text" ref={bidEndInputRef} />
+                        <input
+                            type="text"
+                            value={bidEndInput}
+                            onChange={onChangeBidEnd}
+                        />
                     </LightForm>
                 </>
             )}

--- a/client/components/Artwork/NewArtwork/index.tsx
+++ b/client/components/Artwork/NewArtwork/index.tsx
@@ -12,8 +12,14 @@ interface NewArtworkProp {
 }
 
 const NewArtwork = ({ image }: NewArtworkProp) => {
-    const { onClickDone, titleInputRef, typeInputRef, setModalInputData } =
-        useInputArtwork(image);
+    const {
+        onClickDone,
+        onChangeTitleInput,
+        onChangeTypeInput,
+        titleInput,
+        typeInput,
+        setModalInputData,
+    } = useInputArtwork(image);
     const { backgroundImageRef, imageRef } = usePreviewImage(image);
     const { modalPositionBottom, setModalPositionBottom } =
         useControlModalPosition();
@@ -34,7 +40,8 @@ const NewArtwork = ({ image }: NewArtworkProp) => {
                         <input
                             type="text"
                             placeholder="Title of artwork..."
-                            ref={titleInputRef}
+                            value={titleInput}
+                            onChange={onChangeTitleInput}
                         />
                     </Input>
                     <Input>
@@ -42,7 +49,8 @@ const NewArtwork = ({ image }: NewArtworkProp) => {
                         <input
                             type="text"
                             placeholder="Photography ..."
-                            ref={typeInputRef}
+                            value={typeInput}
+                            onChange={onChangeTypeInput}
                         />
                     </Input>
                 </Form>

--- a/client/components/Artwork/Tiles/ImageTile.tsx
+++ b/client/components/Artwork/Tiles/ImageTile.tsx
@@ -2,10 +2,10 @@ import React, { Suspense } from 'react';
 import styled from '@emotion/styled';
 import Image from 'next/image';
 
-const ImageTile = ({ image }: { image: StaticImageData }) => {
+const ImageTile = ({ src }: { src: string }) => {
     return (
         <Container>
-            <Image src={image} />
+            <Image src={src} />
         </Container>
     );
 };

--- a/client/components/Artwork/Tiles/index.tsx
+++ b/client/components/Artwork/Tiles/index.tsx
@@ -8,7 +8,7 @@ const Tiles = () => {
     const [artworks, setArtwors] = useState([]);
 
     useEffect(() => {
-        // getAllArtworks(1).then((result) => console.log(result));
+        getAllArtworks(1).then((result) => console.log(result));
     }, []);
 
     return (

--- a/client/components/Artwork/Tiles/index.tsx
+++ b/client/components/Artwork/Tiles/index.tsx
@@ -3,17 +3,22 @@ import styled from '@emotion/styled';
 
 import { getAllArtworks } from 'utils/networking';
 import ImageTile from './ImageTile';
+import { Artwork } from 'interfaces';
 
 const Tiles = () => {
-    const [artworks, setArtwors] = useState([]);
+    const [artworks, setArtworks] = useState<Artwork[]>([]);
 
     useEffect(() => {
-        getAllArtworks(1).then((result) => console.log(result));
+        getAllArtworks(1).then((result) => setArtworks(result.data));
     }, []);
 
     return (
         <Container>
-            <Grid></Grid>
+            <Grid>
+                {artworks.map((item, idx: number) => (
+                    <ImageTile key={idx} src={item.imagePath} />
+                ))}
+            </Grid>
         </Container>
     );
 };

--- a/client/hooks/useInputArtwork.ts
+++ b/client/hooks/useInputArtwork.ts
@@ -1,17 +1,17 @@
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 const useInputArtwork = (image: File) => {
     const [modalInputData, setModalInputData] = useState<{
         [key: string]: string;
     }>({});
 
-    const titleInputRef = useRef<HTMLInputElement | null>(null);
-    const typeInputRef = useRef<HTMLInputElement | null>(null);
+    const [titleInput, setTitleInput] = useState('');
+    const [typeInput, setTypeInput] = useState('');
 
     const onClickDone = (e: React.MouseEvent) => {
         const formData = new FormData();
-        formData.append('title', titleInputRef.current!.value);
-        formData.append('type', typeInputRef.current!.value);
+        formData.append('title', titleInput);
+        formData.append('type', typeInput);
         formData.append('description', modalInputData['description']);
         formData.append('year', modalInputData['year']);
         formData.append('bidEnd', modalInputData['bidEnd']);
@@ -20,10 +20,20 @@ const useInputArtwork = (image: File) => {
         // TODO - post FormData to server //
     };
 
+    const onChangeTitleInput = (e: React.FormEvent) => {
+        setTitleInput((e.target as HTMLInputElement).value);
+    };
+
+    const onChangeTypeInput = (e: React.FormEvent) => {
+        setTypeInput((e.target as HTMLInputElement).value);
+    };
+
     return {
         setModalInputData,
-        titleInputRef,
-        typeInputRef,
+        onChangeTitleInput,
+        onChangeTypeInput,
+        titleInput,
+        typeInput,
         onClickDone,
     };
 };

--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -1,1 +1,4 @@
-export interface Artworks {}
+export interface Artwork {
+    id: number;
+    imagePath: string;
+}

--- a/client/pages/login/callback.tsx
+++ b/client/pages/login/callback.tsx
@@ -9,20 +9,19 @@ const LoginCallbackPage = () => {
 
     useEffect(() => {
         let user = null;
-        const code: string | null = new URL(window.location.href)
-            .searchParams
-            .get('code');
+        const code: string | null = new URL(
+            window.location.href,
+        ).searchParams.get('code');
 
         (async () => {
-            if(!code) return;
+            if (!code) return;
 
-            router.asPath.includes('google') ?
-                user = await signIn(code, 'google')
-                : user = await signIn(code, 'kakao');
+            router.asPath.includes('google')
+                ? (user = await signIn(code, 'google'))
+                : (user = await signIn(code, 'kakao'));
 
-            user ? router.push('/') : router.push('/login');
+            user.data ? router.push('/') : router.push('/login');
         })();
-
     }, []);
 
     return (

--- a/client/utils/networking.ts
+++ b/client/utils/networking.ts
@@ -1,14 +1,21 @@
 import axios from 'axios';
+import { Artwork } from 'interfaces';
 
 const API_SERVER_URL = process.env.API_SERVER_URL;
 
 export const getAllArtworks = (userId: number) => {
-    return axios.get(`${API_SERVER_URL}/users/${userId}/artworks`);
+    return axios.get<Artwork[]>(`${API_SERVER_URL}/users/${userId}/artworks`, {
+        withCredentials: true,
+    });
 };
 
 export const signIn = (code: string, strategy: string) => {
-    return axios.post(`${API_SERVER_URL}/auth/signIn`, JSON.stringify({ code, strategy }), {
-        headers: { 'Content-Type': 'Application/JSON' },
-        withCredentials: true
-    });
+    return axios.post(
+        `${API_SERVER_URL}/auth/signIn`,
+        JSON.stringify({ code, strategy }),
+        {
+            headers: { 'Content-Type': 'Application/JSON' },
+            withCredentials: true,
+        },
+    );
 };

--- a/client/utils/networking.ts
+++ b/client/utils/networking.ts
@@ -9,6 +9,13 @@ export const getAllArtworks = (userId: number) => {
     });
 };
 
+export const postArtwork = (data: FormData) => {
+    return axios.post(`${API_SERVER_URL}/artworks`, {
+        withCredentials: true,
+        data: data,
+    });
+};
+
 export const signIn = (code: string, strategy: string) => {
     return axios.post(
         `${API_SERVER_URL}/auth/signIn`,

--- a/client/utils/parseCookie.ts
+++ b/client/utils/parseCookie.ts
@@ -1,0 +1,14 @@
+const parseCookie = () => {
+    let cookieObject: { [key: string]: string } = {};
+    document.cookie.split(/;/gi).forEach((str: string) => {
+        const [key, value] = str.split('=');
+        cookieObject[key.trim()] = value.trim();
+    });
+
+    return (key: string): string | undefined => {
+        console.log(cookieObject);
+        return cookieObject[key];
+    };
+};
+
+export default parseCookie;


### PR DESCRIPTION
### 🔨 작업 내용 설명

아트워크 등록 페이지의 '내 아트워크 조회' 부분에서 api를 연결시키고 소소한 리팩토링을 진행했습니다.
다만, formData를 통해 실제로 파일을 업로드 하는 부분은 api 명세를 아직 몰라 일단 보류시켰습니다.

### 📑 구현한 내용 목록

- [ ] 아트워크 post 페이지 '내 아트워크 조회' 부분 api 연동
- [ ] useRef 기반으로 작성된 input들 useState 기반으로 변경

### 🚧 주의 사항

아트워크 등록이 어려워 테스트해보지 못함.

### 🖥 스크린 샷


close #57
