### PR TITLE
feat: 전시회 리스트 페이지 레이아웃  - #101

### DIFF
--- a/client/components/Footer/index.tsx
+++ b/client/components/Footer/index.tsx
@@ -28,8 +28,8 @@ const Container = styled.div`
     border-top: 2px solid black;
     background-color: white;
     position: relative;
-    bottom: -400px;
-    font-size: ${(props) => props.theme.font.textEnBase};
+    bottom: 0;
+    font: ${(props) => props.theme.font.textEnBase};
     & > div {
         width: 50%;
         height: 70%;

--- a/client/components/Footer/index.tsx
+++ b/client/components/Footer/index.tsx
@@ -24,12 +24,13 @@ const Container = styled.div`
     padding: 0 5%;
     align-items: center;
     height: 300px;
-    width: 100vw;
+    width: 100%;
     border-top: 2px solid black;
     background-color: white;
     position: relative;
     bottom: 0;
     font: ${(props) => props.theme.font.textEnBase};
+
     & > div {
         width: 50%;
         height: 70%;

--- a/client/components/Header/headerStyles.tsx
+++ b/client/components/Header/headerStyles.tsx
@@ -13,7 +13,7 @@ export const defaultHeader = () => {
             <Link href="/auction">
                 <NavButton>Auctions</NavButton>
             </Link>
-            <Link href="/mypage">
+            <Link href="/login">
                 <NavButton>
                     {/* if isLogindata ? imagedata : profilePic.src */}
                     <img src={ProfilePic.src} alt="profile" />
@@ -35,12 +35,12 @@ export const withSearchBar = (isExhibition: boolean) => {
                 />
             </SearchBarContainer>
             <RightContainer>
-                <Link href={isExhibition ? '/exhibition' : '/auction'}>
+                <Link href={isExhibition ? '/auction' : '/exhibition'}>
                     <NavButton>
-                        {isExhibition ? 'Exhibitions' : 'Auctions'}
+                        {isExhibition ? 'Auctions' : 'Exhibitions'}
                     </NavButton>
                 </Link>
-                <Link href="/mypage">
+                <Link href="/login">
                     <NavButton>
                         {/* if isLogindata ? imagedata : profilePic.src */}
                         <img src={ProfilePic.src} alt="profile" />

--- a/client/components/Header/style.ts
+++ b/client/components/Header/style.ts
@@ -3,6 +3,7 @@ import { SpaceBetween, Center } from '@styles/common';
 
 export const HeaderContainer = styled.header`
     position: fixed;
+    z-index: 100;
     top: 0;
     left: 0;
     width: 100%;

--- a/client/components/common/Layout.tsx
+++ b/client/components/common/Layout.tsx
@@ -20,9 +20,11 @@ const Layout = ({ children }: LayoutProps) => {
 
 const Body = styled.div`
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    justify-content: flex-start;
     align-items: center;
     padding-top: 100px;
+    min-height: calc(100vh - 300px);
 `;
 
 export default Layout;

--- a/client/pages/exhibition/index.tsx
+++ b/client/pages/exhibition/index.tsx
@@ -1,8 +1,187 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { NextPage } from 'next';
+import styled from '@emotion/styled';
+import { Button, SpaceBetween } from '@styles/common';
+import Layout from '@components/common/Layout';
+import { ExhibitionCardProps } from '@const/card-type';
+import Card from '@components/Card';
+import Link from 'next/link';
+
+const dummyExihibition: ExhibitionCardProps[] = [
+    {
+        id: 1,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+    {
+        id: 2,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+    {
+        id: 3,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+    {
+        id: 4,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+    {
+        id: 5,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+    {
+        id: 6,
+        title: '제목',
+        description: '설명',
+        artist: '작가',
+        imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
+        category: '사진',
+        theme: '부스트캠프',
+        artCount: 3,
+        isSale: true,
+    },
+];
 
 const ExhibitionPage: NextPage = () => {
-    return <div></div>;
+    const [onSelect, setOnSelect] = useState<string>('Newest');
+
+    const onSelectFilter = ({ currentTarget }: React.MouseEvent) => {
+        setOnSelect(currentTarget.textContent || 'Newest');
+    };
+
+    return (
+        <Layout>
+            <TopContainer>
+                <FilterWrapper>
+                    <Filter
+                        select={onSelect === 'Newest'}
+                        onClick={onSelectFilter}
+                    >
+                        Newest
+                    </Filter>
+                    <Filter
+                        select={onSelect === 'Popular'}
+                        onClick={onSelectFilter}
+                    >
+                        Popular
+                    </Filter>
+                    <Filter
+                        select={onSelect === 'Deadline'}
+                        onClick={onSelectFilter}
+                    >
+                        Deadline
+                    </Filter>
+                </FilterWrapper>
+
+                <Buttons>
+                    <BlackButton>Hold Exhibition</BlackButton>
+                    <Link href="/artwork/post">
+                        <BlackButton>Post Artwork</BlackButton>
+                    </Link>
+                </Buttons>
+            </TopContainer>
+
+            <ExhibitionList>
+                {dummyExihibition.map((exihibition) => (
+                    <Card
+                        key={exihibition.id}
+                        width="lg"
+                        content={exihibition}
+                    />
+                ))}
+            </ExhibitionList>
+        </Layout>
+    );
 };
+
+interface FilterProps {
+    select: boolean;
+}
+
+const TopContainer = styled.div`
+    display: flex;
+    width: 1180px;
+    margin-bottom: 45px;
+`;
+
+const FilterWrapper = styled.div`
+    ${SpaceBetween}
+`;
+
+const Filter = styled.button<FilterProps>`
+    height: 30px;
+    padding: 0px 30px;
+    border: none;
+    border-left: 1px solid #a6a6a6;
+
+    font: ${(props) =>
+        props.select ? props.theme.font.textEnLg : props.theme.font.textEnMd};
+    color: ${(props) => (props.select ? props.theme.color.primary : '#757575')};
+
+    background: none;
+
+    &:first-of-type {
+        border-left: none;
+    }
+`;
+
+const Buttons = styled.div`
+    margin-left: auto;
+`;
+
+const BlackButton = styled(Button)`
+    color: black;
+    border-bottom: 1px solid black;
+    font: ${(props) => props.theme.font.textEnLg};
+
+    &:first-of-type {
+        margin-right: 25px;
+    }
+`;
+
+const ExhibitionList = styled.div`
+    ${SpaceBetween}
+    flex-wrap: wrap;
+
+    width: 1180px;
+
+    & > div {
+        margin-bottom: 45px;
+    }
+`;
 
 export default ExhibitionPage;

--- a/client/styles/common.ts
+++ b/client/styles/common.ts
@@ -29,4 +29,8 @@ export const Button = styled.button`
     font-size: 20px;
     font-weight: 200;
     color: white;
+
+    &:hover {
+        border-bottom: 2px solid ${(props) => props.theme.color.primary};
+    }
 `;


### PR DESCRIPTION
### 🔨 작업 내용 설명

전시회 리스트 페이지 레이아웃 구현과 기타 css 설정 수정을 했습니다.

### 📑 구현한 내용 목록

- [ ] 전시회 리스트 더미 데이터를 이용한 레이아웃 구현
- [ ] header z-index추가로 card 컴포넌트들이 header위에 보이는 현상 해결
- [ ] layout 컴포넌트 최소 크기 지정해서 footer 바텀에 고정
- [ ] footer 100vw -> 100%  변경해서 위아래 scroll이 생겨도 좌우 scorll이 생기지 않도록 함.

### 🚧 주의 사항

전시회 리스트 조회 API 나오면 인피니티 스크롤 추가와 더미 데이터 제거

### 🖥 스크린 샷

![image](https://user-images.githubusercontent.com/15667978/140287674-38b149e8-30e8-421b-a6e3-470752d47a69.png)

close #101 