### PR TITLE
feat: 전시회 리스트 조회 API 구현 - #109

### DIFF
--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -2,11 +2,16 @@ import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { ExhibitionService } from '../service/exhibition.service';
 import { Exhibition } from '../exhibition.entity';
 import {
-    ApiCreatedResponse,
     ApiOperation,
-    ApiProperty,
+    ApiProperty, ApiResponse,
     ApiTags,
 } from '@nestjs/swagger';
+import {
+    getExhibitionApiResponse, getExhibitionsSortedByDeadlineApiOperation, getExhibitionsSortedByInterestApiOperation,
+    getNewestExhibitionApiOperation,
+    getRandomExhibitionApiResponse,
+    getRandomExhibitionsAPiOperation,
+} from '../swagger';
 
 @ApiTags('전시회 컨트롤러')
 @Controller('/exhibitions')
@@ -14,31 +19,30 @@ export class ExhibitionController {
     constructor(private exhibitionService: ExhibitionService) {}
 
     @Get('/random')
-    @ApiOperation({
-        summary: '전시회 랜덤 5개 조회 API',
-        description: '랜덤으로 전시회 5개를 조회한다.',
-    })
-    @ApiCreatedResponse({
-        description: '전시회 객체 5개 배열',
-        type: Exhibition,
-        isArray: true,
-    })
+    @ApiOperation(getRandomExhibitionsAPiOperation)
+    @ApiResponse(getRandomExhibitionApiResponse)
     @ApiProperty({})
     getRandomExhibitions(): Promise<Exhibition[]> {
         return this.exhibitionService.getRandomExhibitions();
     }
 
     @Get('/newest')
+    @ApiOperation(getNewestExhibitionApiOperation)
+    @ApiResponse(getExhibitionApiResponse)
     getNewestExhibition(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getNewestExhibitions(page);
     }
 
     @Get('/deadline')
+    @ApiOperation(getExhibitionsSortedByDeadlineApiOperation)
+    @ApiResponse(getExhibitionApiResponse)
     getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getExhibitionsSortedByDeadline(page);
     }
 
     @Get('/popular')
+    @ApiOperation(getExhibitionsSortedByInterestApiOperation)
+    @ApiResponse(getExhibitionApiResponse)
     getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getExhibitionsSortedByInterest(page);
     }

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -29,7 +29,7 @@ export class ExhibitionController {
     @Get('/newest')
     @ApiOperation(getNewestExhibitionApiOperation)
     @ApiResponse(getExhibitionApiResponse)
-    getNewestExhibition(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+    getNewestExhibitions(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getNewestExhibitions(page);
     }
 

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -3,7 +3,7 @@ import { ExhibitionService } from '../service/exhibition.service';
 import { Exhibition } from '../exhibition.entity';
 import {
     ApiOperation,
-    ApiProperty, ApiResponse,
+    ApiProperty, ApiQuery, ApiResponse,
     ApiTags,
 } from '@nestjs/swagger';
 import {
@@ -29,6 +29,7 @@ export class ExhibitionController {
     @Get('/newest')
     @ApiOperation(getNewestExhibitionApiOperation)
     @ApiResponse(getExhibitionApiResponse)
+    @ApiQuery({name: "page", type: Number })
     getNewestExhibitions(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getNewestExhibitions(page);
     }
@@ -36,6 +37,7 @@ export class ExhibitionController {
     @Get('/deadline')
     @ApiOperation(getExhibitionsSortedByDeadlineApiOperation)
     @ApiResponse(getExhibitionApiResponse)
+    @ApiQuery({name: "page", type: Number })
     getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getExhibitionsSortedByDeadline(page);
     }
@@ -43,6 +45,7 @@ export class ExhibitionController {
     @Get('/popular')
     @ApiOperation(getExhibitionsSortedByInterestApiOperation)
     @ApiResponse(getExhibitionApiResponse)
+    @ApiQuery({name: "page", type: Number })
     getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
         return this.exhibitionService.getExhibitionsSortedByInterest(page);
     }

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { ExhibitionService } from '../service/exhibition.service';
 import { Exhibition } from '../exhibition.entity';
 import {
@@ -8,9 +8,8 @@ import {
     ApiTags,
 } from '@nestjs/swagger';
 
-@Controller('/exhibitions')
 @ApiTags('전시회 컨트롤러')
-
+@Controller('/exhibitions')
 export class ExhibitionController {
     constructor(private exhibitionService: ExhibitionService) {}
 
@@ -28,4 +27,21 @@ export class ExhibitionController {
     getRandomExhibitions(): Promise<Exhibition[]> {
         return this.exhibitionService.getRandomExhibitions();
     }
+
+    @Get('/newest')
+    getNewestExhibition(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+        return this.exhibitionService.getNewestExhibitions(page);
+    }
+
+    @Get('/deadline')
+    getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+        return this.exhibitionService.getExhibitionsSortedByDeadline(page);
+    }
+
+    @Get('/popular')
+    getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+        return this.exhibitionService.getExhibitionsSortedByInterest(page);
+    }
+
+
 }

--- a/server/src/exhibition/exhibition.repository.ts
+++ b/server/src/exhibition/exhibition.repository.ts
@@ -1,5 +1,7 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, Repository } from 'typeorm';
 import { Exhibition } from "./exhibition.entity";
+import { Artwork } from '../artwork/artwork.entity';
+import { InterestArtwork } from '../interestArtwork/interestArtwork.entity';
 
 @EntityRepository(Exhibition)
 export class ExhibitionRepository extends Repository<Exhibition> {
@@ -10,4 +12,41 @@ export class ExhibitionRepository extends Repository<Exhibition> {
             .limit(5)
             .getMany();
     }
+
+    async getNewestExhibitions(page: number): Promise<Exhibition[]> {
+        return await this.createQueryBuilder('exhibition')
+            .where('exhibition.start_at <= now()')
+            .orderBy(`now() - exhibition.start_at`, 'ASC')
+            .offset(page * 15)
+            .limit(15)
+            .getMany();
+    }
+
+    async getExhibitionsSortedByDeadline(page: number): Promise<Exhibition[]> {
+        return await this.createQueryBuilder('exhibition')
+            .orderBy('exhibition.end_at - now()', 'ASC')
+            .offset(page * 15)
+            .limit(15)
+            .getMany();
+    }
+
+    async getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
+        return await this.createQueryBuilder('exhibition')
+            .innerJoin(subQuery => {
+                return subQuery
+                    .select('artwork.exhibition_id')
+                    .from(Artwork, 'artwork')
+                    .innerJoin(
+                        InterestArtwork,
+                        'interest_artwork',
+                        'artwork.id = interest_artwork.artwork_id'
+                    )
+            }, 'artwork', 'artwork.exhibition_id = exhibition.id')
+            .groupBy('exhibition.id')
+            .orderBy('count(exhibition.id)', 'DESC')
+            .offset(page * 15)
+            .limit(15)
+            .getMany();
+    }
+
 }

--- a/server/src/exhibition/service/exhibition.service.ts
+++ b/server/src/exhibition/service/exhibition.service.ts
@@ -22,7 +22,7 @@ export class ExhibitionService {
         return this.exhibitionRepository.getExhibitionsSortedByDeadline(page);
     }
 
-    async getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
+    getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
         return this.exhibitionRepository.getExhibitionsSortedByInterest(page);
     }
 

--- a/server/src/exhibition/service/exhibition.service.ts
+++ b/server/src/exhibition/service/exhibition.service.ts
@@ -14,4 +14,16 @@ export class ExhibitionService {
         return this.exhibitionRepository.getRandomExhibitions();
     }
 
+    getNewestExhibitions(page: number): Promise<Exhibition[]> {
+        return this.exhibitionRepository.getNewestExhibitions(page);
+    }
+
+    getExhibitionsSortedByDeadline(page: number): Promise<Exhibition[]> {
+        return this.exhibitionRepository.getExhibitionsSortedByDeadline(page);
+    }
+
+    async getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
+        return this.exhibitionRepository.getExhibitionsSortedByInterest(page);
+    }
+
 }

--- a/server/src/exhibition/swagger/index.ts
+++ b/server/src/exhibition/swagger/index.ts
@@ -1,0 +1,33 @@
+import { Exhibition } from '../exhibition.entity';
+
+export const getRandomExhibitionsAPiOperation = {
+    summary: '전시회 랜덤 5개 조회 API',
+    description: '랜덤으로 전시회 5개를 조회한다.',
+}
+
+export const getRandomExhibitionApiResponse = {
+    description: '전시회 객체 5개 배열',
+    type: Exhibition,
+    isArray: true,
+}
+
+export const getNewestExhibitionApiOperation = {
+    summary: '최신순 전시회 15개 조회 API',
+    description: '최신순으로 전시회 15개를 조회한다.'
+}
+
+export const getExhibitionApiResponse = {
+    description: '전시회 객체 15개 배열',
+    type: Exhibition,
+    isArray: true,
+}
+
+export const getExhibitionsSortedByDeadlineApiOperation = {
+    summary: '마감임박순 전시회 15개 조회 API',
+    description: '마감임박순으로 전시회 15개를 조회한다.'
+};
+
+export const getExhibitionsSortedByInterestApiOperation = {
+    summary: '관심순 전시회 15개 조회 API',
+    description: '관심순으로 전시회 15개를 조회한다.'
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 최신순, 마감임박순, 관심순 전시회 리스트 조회 API 구현

### 📑 구현한 내용 목록

- [x] 최신순 전시회 리스트 API 구현
- [x] 마감임박순 전시회 리스트 API 구현
- [x] 관심순 전시회 리스트 API 구현

### 🚧 주의 사항

### 🖥 스크린 샷

close #109 
