### PR TITLE
feat: 로그인 API 개선 및 로그아웃 API 구현 - #118

### DIFF
--- a/server/src/auth/controller/auth.controller.ts
+++ b/server/src/auth/controller/auth.controller.ts
@@ -20,13 +20,14 @@ export class AuthController {
         try {
             let user = null;
             strategy === 'google'
-                ? (user = await this.authService.signInWithGoogle(code))
-                : (user = await this.authService.signInWithKakao(code));
+                ? user = await this.authService.signInWithGoogle(code)
+                : user = await this.authService.signInWithKakao(code);
 
             const { accessToken, refreshToken } = user;
+            const oneHour = 1000 * 60 * 60, oneWeek = 1000 * 60 * 60 * 24 * 7;
 
-            res.cookie('accessToken', accessToken);
-            res.cookie('refreshToken', refreshToken);
+            res.cookie('accessToken', accessToken, { maxAge: oneHour });
+            res.cookie('refreshToken', refreshToken, { maxAge: oneWeek });
             res.json(true);
         } catch (err) {
             res.json(false);

--- a/server/src/auth/controller/auth.controller.ts
+++ b/server/src/auth/controller/auth.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, ParseIntPipe, Post, Res } from '@nestjs/common';
 import { AuthService } from '../service/auth.service';
 import { Response } from 'express';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { signInApiBody, signInApiOperation } from '../swagger';
+import { signInApiBody, signInApiOperation, signOutApiBody, signOutApiOperation } from '../swagger';
 
 @Controller('/auth')
 @ApiTags('인증 컨트롤러')
@@ -35,6 +35,8 @@ export class AuthController {
     }
 
     @Post('/signOut')
+    @ApiOperation(signOutApiOperation)
+    @ApiBody(signOutApiBody)
     async signOut(
         @Body('userId', ParseIntPipe) userId: number,
         @Res() res: Response

--- a/server/src/auth/controller/auth.controller.ts
+++ b/server/src/auth/controller/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Res } from '@nestjs/common';
+import { Body, Controller, ParseIntPipe, Post, Res } from '@nestjs/common';
 import { AuthService } from '../service/auth.service';
 import { Response } from 'express';
 import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -18,7 +18,7 @@ export class AuthController {
         @Res() res: Response,
     ): Promise<void> {
         try {
-            let user = null;
+            let user;
             strategy === 'google'
                 ? user = await this.authService.signInWithGoogle(code)
                 : user = await this.authService.signInWithKakao(code);
@@ -33,4 +33,17 @@ export class AuthController {
             res.json(false);
         }
     }
+
+    @Post('/signOut')
+    async signOut(
+        @Body('userId', ParseIntPipe) userId: number,
+        @Res() res: Response
+    ): Promise<void> {
+        await this.authService.signOut(userId);
+
+        res.clearCookie('accessToken');
+        res.clearCookie('refreshToken');
+        res.end();
+    }
+
 }

--- a/server/src/auth/guard/CustomAuthGuard.ts
+++ b/server/src/auth/guard/CustomAuthGuard.ts
@@ -38,8 +38,8 @@ export class CustomAuthGuard extends AuthGuard('jwt') {
 
     async verifyToken(token: string): Promise<User> {
         try {
-            const { userId } = this.jwtService.verify(token);
-            return await this.userRepository.findOne({ userId });
+            const { userId, loginStrategy } = this.jwtService.verify(token);
+            return await this.userRepository.findOne({ userId, loginStrategy });
         } catch(err) {
             return null;
         }

--- a/server/src/auth/service/auth.service.ts
+++ b/server/src/auth/service/auth.service.ts
@@ -29,9 +29,9 @@ export class AuthService {
         const userInfo = await axios.get(process.env.GOOGLE_USER_URL, {
             headers: { Authorization: `Bearer ${access_token}`}
         });
-        const { email, picture } = userInfo.data;
+        const { email, name, picture } = userInfo.data;
 
-        const user = await this.userService.checkRegisteredUser(email, picture, 'google');
+        const user = await this.userService.checkRegisteredUser(email, name, picture, 'google');
         return this.generateToken(user, 'google');
     }
 
@@ -53,7 +53,7 @@ export class AuthService {
         });
         const { email, profile } = userInfo.data.kakao_account;
 
-        const user = await this.userService.checkRegisteredUser(email, profile.profile_image_url, 'kakao');
+        const user = await this.userService.checkRegisteredUser(email, profile.nickname, profile.profile_image_url, 'kakao');
         return this.generateToken(user, 'kakao');
     }
 

--- a/server/src/auth/service/auth.service.ts
+++ b/server/src/auth/service/auth.service.ts
@@ -62,8 +62,9 @@ export class AuthService {
             userId: user.userId,
             loginStrategy
         };
-        const accessToken = this.jwtService.sign(payload, { expiresIn: 60 * 60 });
-        const refreshToken = this.jwtService.sign(payload, { expiresIn: 60 * 60 * 24 * 7 });
+        const oneHour = 60 * 60, oneWeek = 60 * 60 * 24 * 7;
+        const accessToken = this.jwtService.sign(payload, { expiresIn: oneHour });
+        const refreshToken = this.jwtService.sign(payload, { expiresIn: oneWeek });
 
         await this.userService.updateUserToken(user.id, refreshToken);
         return { accessToken, refreshToken };

--- a/server/src/auth/service/auth.service.ts
+++ b/server/src/auth/service/auth.service.ts
@@ -28,9 +28,9 @@ export class AuthService {
         const userInfo = await axios.get(process.env.GOOGLE_USER_URL, {
             headers: { Authorization: `Bearer ${access_token}`}
         });
-        const { email } = userInfo.data;
+        const { email, picture } = userInfo.data;
 
-        const user = await this.userService.checkRegisteredUser(email, 'google');
+        const user = await this.userService.checkRegisteredUser(email, picture, 'google');
         return this.generateToken(user);
     }
 
@@ -50,9 +50,9 @@ export class AuthService {
         const userInfo = await axios.get(process.env.KAKAO_USER_URL, {
             headers: { Authorization: `Bearer ${access_token}`}
         });
-        const { kakao_account }: {[key: string]: any} = userInfo.data;
+        const { email, profile } = userInfo.data.kakao_account;
 
-        const user = await this.userService.checkRegisteredUser(kakao_account.email, 'kakao');
+        const user = await this.userService.checkRegisteredUser(email, profile.profile_image_url, 'kakao');
         return this.generateToken(user);
     }
 

--- a/server/src/auth/swagger/index.ts
+++ b/server/src/auth/swagger/index.ts
@@ -12,3 +12,17 @@ export const signInApiBody = {
         },
     },
 };
+
+export const signOutApiOperation = {
+    summary: '로그아웃 API',
+    description: '로그아웃을 담당합니다.'
+};
+
+export const signOutApiBody = {
+    schema: {
+        type: 'object',
+        properties: {
+            userId: { type: 'string', nullable: false }
+        },
+    },
+};

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -4,6 +4,7 @@ import { UserRepository } from '../user.repository';
 import { ArtworkRepository } from '../../artwork/artwork.repository';
 import { Artwork } from '../../artwork/artwork.entity';
 import { User } from '../user.entity';
+import { UpdateResult } from 'typeorm';
 
 @Injectable()
 export class UserService {
@@ -28,8 +29,8 @@ export class UserService {
         return user;
     }
 
-    async updateUserToken(id: number, refreshToken: string): Promise<void> {
-        await this.userRepository.update(id, { refreshToken });
+    updateUserToken(id: number, refreshToken: string): Promise<UpdateResult> {
+        return this.userRepository.update(id, { refreshToken });
     }
 
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -18,11 +18,11 @@ export class UserService {
         return this.artworkRepository.getAllUsersArtworks(userId);
     }
 
-    async checkRegisteredUser(userId: string, loginStrategy: string): Promise<User> {
+    async checkRegisteredUser(userId: string, avatar: string, loginStrategy: string): Promise<User> {
         let user = await this.userRepository.findOne({ userId, loginStrategy });
 
         if(!user) {
-            user = await this.userRepository.createUser(userId, loginStrategy);
+            user = await this.userRepository.createUser(userId, avatar, loginStrategy);
         }
 
         return user;

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -19,11 +19,11 @@ export class UserService {
         return this.artworkRepository.getAllUsersArtworks(userId);
     }
 
-    async checkRegisteredUser(userId: string, avatar: string, loginStrategy: string): Promise<User> {
+    async checkRegisteredUser(userId: string, name:string, avatar: string, loginStrategy: string): Promise<User> {
         let user = await this.userRepository.findOne({ userId, loginStrategy });
 
         if(!user) {
-            user = await this.userRepository.createUser(userId, avatar, loginStrategy);
+            user = await this.userRepository.createUser(userId, name, avatar, loginStrategy);
         }
 
         return user;

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -14,7 +14,7 @@ export class User {
     userId: string;
 
     @Column({ nullable: true })
-    nickname: string;
+    name: string;
 
     @Column({ nullable: true })
     snsId: string;

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -4,9 +4,10 @@ import { User } from './user.entity';
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
 
-    async createUser(userId: string, avatar: string, loginStrategy: string): Promise<User> {
+    async createUser(userId: string, name: string, avatar: string, loginStrategy: string): Promise<User> {
         const user = this.create({
             userId,
+            name,
             avatar,
             loginStrategy
         });

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -4,8 +4,12 @@ import { User } from './user.entity';
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
 
-    async createUser(userId: string, loginStrategy: string): Promise<User> {
-        const user = this.create({ userId, loginStrategy });
+    async createUser(userId: string, avatar: string, loginStrategy: string): Promise<User> {
+        const user = this.create({
+            userId,
+            avatar,
+            loginStrategy
+        });
 
         return await this.save(user);
     }


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 첫 로그인 시 프로필 사진 추가
- cookie에 담긴 token 유효 시간 지정
- JWT payload에 사용자 ID 뿐만 아니라 로그인 전략을 추가하여 확실히 사용자를 구분할 수 있도록 함
- 로그아웃 API 구현

### 📑 구현한 내용 목록
- [x] 첫 로그인 시 프로필 사진 추가
- [x] 로그아웃 API 구현

### 🚧 주의 사항
- 현재 사용자 정보 저장 시 전달되는 파라미터가 너무 많은데, 이를 객체로 묶을 방법을 생각해보는 중입니다.
`const user = await this.userService.checkRegisteredUser(email, name, picture, 'google');`
`const user = await this.userService.checkRegisteredUser(email, profile.nickname, profile.profile_image_url, 'kakao');`

### 🖥 스크린 샷

close #118 
