### PR TITLE
feat: 옥션 관련 apis 기능 개발 - #116

### DIFF
--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -4,6 +4,6 @@
     "useTabs": false,
     "tabWidth": 4,
     "trailingComma": "all",
-    "printWidth": 80,
+    "printWidth": 120,
     "arrowParens": "avoid"
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,7 @@ import { ExhibitionModule } from './exhibition/exhibition.module';
 import { ArtworkModule } from './artwork/artwork.module';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
+import { AuctionModule } from './auction/auction.module';
 
 @Module({
     imports: [
@@ -13,6 +14,7 @@ import { AuthModule } from './auth/auth.module';
         ArtworkModule,
         UserModule,
         AuthModule,
+        AuctionModule,
     ],
 })
 export class AppModule {}

--- a/server/src/auction/auction.module.ts
+++ b/server/src/auction/auction.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuctionRepository } from './auction.repository';
+import AuctionController from './controller/auction.controller';
+import AuctionService from './service/auction.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([AuctionRepository])],
+    controllers: [AuctionController],
+    providers: [AuctionService],
+})
+export class AuctionModule {}

--- a/server/src/auction/auction.repository.ts
+++ b/server/src/auction/auction.repository.ts
@@ -14,6 +14,14 @@ export class AuctionRepository extends Repository<Auction> {
         }
     }
 
+    getRandomAuctions(): Promise<Auction[]> {
+        return this.createQueryBuilder('auction')
+            .innerJoinAndSelect('auction.artwork', 'artwork')
+            .orderBy('RAND()')
+            .limit(3)
+            .getMany();
+    }
+
     findAllByAuctionOrderByNewest(page: number): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')

--- a/server/src/auction/auction.repository.ts
+++ b/server/src/auction/auction.repository.ts
@@ -11,4 +11,12 @@ export class AuctionRepository extends Repository<Auction> {
             });
         }
     }
+
+    getAuctionsWithPageable(page: number): Promise<Auction[]> {
+        return this.createQueryBuilder('auction')
+            .innerJoinAndSelect('auction.artwork', 'artwork')
+            .offset(page * 15)
+            .limit(15)
+            .getMany();
+    }
 }

--- a/server/src/auction/auction.repository.ts
+++ b/server/src/auction/auction.repository.ts
@@ -12,11 +12,21 @@ export class AuctionRepository extends Repository<Auction> {
         }
     }
 
-    getAuctionsWithPageable(page: number): Promise<Auction[]> {
+    findAllByAuctionWithArtworkAndPageable(page: number): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')
             .offset(page * 15)
             .limit(15)
             .getMany();
+    }
+
+    findByAuctionWithAuctionHistoryAndArtwork(
+        auctionId: number,
+    ): Promise<Auction> {
+        return this.createQueryBuilder('auction')
+            .where(`auction.id = ${auctionId}`)
+            .leftJoinAndSelect('auction.auctionHistories', 'history')
+            .innerJoinAndSelect('auction.artwork', 'artwork')
+            .getOne();
     }
 }

--- a/server/src/auction/auction.repository.ts
+++ b/server/src/auction/auction.repository.ts
@@ -1,4 +1,6 @@
+import { Artwork } from 'src/artwork/artwork.entity';
 import { CreateArtworkDTO } from 'src/artwork/dto/artworkDTOs';
+import { InterestArtwork } from 'src/interestArtwork/interestArtwork.entity';
 import { EntityRepository, Repository } from 'typeorm';
 import { Auction } from './auction.entity';
 
@@ -12,17 +14,36 @@ export class AuctionRepository extends Repository<Auction> {
         }
     }
 
-    findAllByAuctionWithArtworkAndPageable(page: number): Promise<Auction[]> {
+    findAllByAuctionOrderByNewest(page: number): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')
+            .orderBy('auction.id', 'DESC')
             .offset(page * 15)
             .limit(15)
             .getMany();
     }
 
-    findByAuctionWithAuctionHistoryAndArtwork(
-        auctionId: number,
-    ): Promise<Auction> {
+    findAllByAuctionOrderByPopular(page: number): Promise<Auction[]> {
+        return this.createQueryBuilder('auction')
+            .innerJoinAndSelect('auction.artwork', 'artwork')
+            .innerJoin(
+                subQuery =>
+                    subQuery
+                        .select('a.id, count(i.artwork_id) as count')
+                        .from(Artwork, 'a')
+                        .leftJoin(InterestArtwork, 'i', 'a.id = i.artwork_id')
+                        .groupBy('a.id'),
+                'interest',
+                'artwork.id = interest.id',
+            )
+            .orderBy('interest.count', 'DESC')
+            .addOrderBy('auction.id', 'DESC')
+            .offset(page * 15)
+            .limit(15)
+            .getMany();
+    }
+
+    findByAuctionWithAuctionHistoryAndArtwork(auctionId: number): Promise<Auction> {
         return this.createQueryBuilder('auction')
             .where(`auction.id = ${auctionId}`)
             .leftJoinAndSelect('auction.auctionHistories', 'history')

--- a/server/src/auction/controller/auction.controller.ts
+++ b/server/src/auction/controller/auction.controller.ts
@@ -1,16 +1,11 @@
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
-import {
-    ApiBody,
-    ApiOperation,
-    ApiQuery,
-    ApiResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuctionDetailDTO, AuctionListItemDTO } from '../dto/auctionDTOs';
 import AuctionService from '../service/auction.service';
 import {
-    getAuctionsWithInfinityScrollApiOperation,
     getAuctionDetailApiOperation,
+    getAuctionsSortedByPopularApiOperation,
+    getAuctionsSortedByNewsestApiOperation,
 } from '../swagger';
 
 @Controller('acutions')
@@ -18,22 +13,26 @@ import {
 export default class AuctionController {
     constructor(private readonly auctionService: AuctionService) {}
 
-    @Get()
-    @ApiOperation(getAuctionsWithInfinityScrollApiOperation)
+    @Get('/newest')
+    @ApiOperation(getAuctionsSortedByNewsestApiOperation)
     @ApiQuery({ name: 'page', type: Number })
     @ApiResponse({ type: AuctionListItemDTO })
-    getAuctionsWithInfinityScroll(
-        @Query('page', ParseIntPipe) page: number,
-    ): Promise<AuctionListItemDTO[]> {
-        return this.auctionService.getAuctionsWithPageable(page);
+    getAuctionsOrderByNewsest(@Query('page', ParseIntPipe) page: number): Promise<AuctionListItemDTO[]> {
+        return this.auctionService.getAuctionsSortedByNewest(page);
+    }
+
+    @Get('/popular')
+    @ApiOperation(getAuctionsSortedByPopularApiOperation)
+    @ApiQuery({ name: 'page', type: Number })
+    @ApiResponse({ type: AuctionListItemDTO })
+    getAuctionsOrderByPopular(@Query('page', ParseIntPipe) page: number): Promise<AuctionListItemDTO[]> {
+        return this.auctionService.getAuctionsSortedByPopular(page);
     }
 
     @Get(':id')
     @ApiOperation(getAuctionDetailApiOperation)
     @ApiResponse({ type: AuctionDetailDTO })
-    getAuctionDetail(
-        @Param('id', ParseIntPipe) auctionId: number,
-    ): Promise<AuctionDetailDTO> {
+    getAuctionDetail(@Param('id', ParseIntPipe) auctionId: number): Promise<AuctionDetailDTO> {
         return this.auctionService.getAuctionDetail(auctionId);
     }
 }

--- a/server/src/auction/controller/auction.controller.ts
+++ b/server/src/auction/controller/auction.controller.ts
@@ -30,11 +30,10 @@ export default class AuctionController {
 
     @Get(':id')
     @ApiOperation(getAuctionDetailApiOperation)
-    @ApiBody({ type: Number })
+    @ApiResponse({ type: AuctionDetailDTO })
     getAuctionDetail(
-        @Param('id', ParseIntPipe) auctionId: Number,
+        @Param('id', ParseIntPipe) auctionId: number,
     ): Promise<AuctionDetailDTO> {
-        // @ TODO API 개발
-        return;
+        return this.auctionService.getAuctionDetail(auctionId);
     }
 }

--- a/server/src/auction/controller/auction.controller.ts
+++ b/server/src/auction/controller/auction.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+    ApiBody,
+    ApiOperation,
+    ApiQuery,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { AuctionDetailDTO, AuctionListItemDTO } from '../dto/auctionDTOs';
+import AuctionService from '../service/auction.service';
+import {
+    getAuctionsWithInfinityScrollApiOperation,
+    getAuctionDetailApiOperation,
+} from '../swagger';
+
+@Controller('acutions')
+@ApiTags('옥션 컨트롤러')
+export default class AuctionController {
+    constructor(private readonly auctionService: AuctionService) {}
+
+    @Get()
+    @ApiOperation(getAuctionsWithInfinityScrollApiOperation)
+    @ApiQuery({ name: 'page', type: Number })
+    @ApiResponse({ type: AuctionListItemDTO })
+    getAuctionsWithInfinityScroll(
+        @Query('page', ParseIntPipe) page: number,
+    ): Promise<AuctionListItemDTO[]> {
+        return this.auctionService.getAuctionsWithPageable(page);
+    }
+
+    @Get(':id')
+    @ApiOperation(getAuctionDetailApiOperation)
+    @ApiBody({ type: Number })
+    getAuctionDetail(
+        @Param('id', ParseIntPipe) auctionId: Number,
+    ): Promise<AuctionDetailDTO> {
+        // @ TODO API 개발
+        return;
+    }
+}

--- a/server/src/auction/controller/auction.controller.ts
+++ b/server/src/auction/controller/auction.controller.ts
@@ -6,12 +6,20 @@ import {
     getAuctionDetailApiOperation,
     getAuctionsSortedByPopularApiOperation,
     getAuctionsSortedByNewsestApiOperation,
+    getRandomAuctionsApiOperation,
 } from '../swagger';
 
 @Controller('acutions')
 @ApiTags('옥션 컨트롤러')
 export default class AuctionController {
     constructor(private readonly auctionService: AuctionService) {}
+
+    @Get('/random')
+    @ApiOperation(getRandomAuctionsApiOperation)
+    @ApiResponse({ type: AuctionListItemDTO })
+    getRandomAuctions(): Promise<AuctionListItemDTO[]> {
+        return this.auctionService.getRandomAuctions();
+    }
 
     @Get('/newest')
     @ApiOperation(getAuctionsSortedByNewsestApiOperation)

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Artwork } from 'src/artwork/artwork.entity';
+import { AuctionHistory } from 'src/auctionHistory/auctionHistory.entity';
 import { Auction } from '../auction.entity';
 
 export class AuctionListItemDTO {
@@ -15,4 +16,19 @@ export class AuctionListItemDTO {
     artwork: Artwork;
 }
 
-export class AuctionDetailDTO {}
+export class AuctionDetailDTO {
+    constructor(auction: Auction) {
+        this.id = auction.id;
+        this.artowrk = auction.artwork;
+        this.auctionHistories = auction.auctionHistories;
+    }
+
+    @ApiProperty()
+    id: number;
+
+    @ApiProperty()
+    artowrk: Artwork;
+
+    @ApiProperty()
+    auctionHistories: AuctionHistory[];
+}

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -28,6 +28,12 @@ export class AuctionDetailDTO {
     @ApiProperty()
     auctionHistories: AuctionHistory[];
 
+    @ApiProperty()
+    startAt: Date;
+
+    @ApiProperty()
+    endAt: Date;
+
     static from(auction: Auction): AuctionDetailDTO {
         const dto = new AuctionDetailDTO();
         dto.id = auction.id;

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -4,31 +4,35 @@ import { AuctionHistory } from 'src/auctionHistory/auctionHistory.entity';
 import { Auction } from '../auction.entity';
 
 export class AuctionListItemDTO {
-    constructor(auction: Auction) {
-        this.id = auction.id;
-        this.artwork = auction.artwork;
-    }
-
     @ApiProperty()
     id: number;
 
     @ApiProperty()
     artwork: Artwork;
+
+    static from(auction: Auction): AuctionListItemDTO {
+        const dto = new AuctionListItemDTO();
+        dto.id = auction.id;
+        dto.artwork = auction.artwork;
+        return dto;
+    }
 }
 
 export class AuctionDetailDTO {
-    constructor(auction: Auction) {
-        this.id = auction.id;
-        this.artowrk = auction.artwork;
-        this.auctionHistories = auction.auctionHistories;
-    }
-
     @ApiProperty()
     id: number;
 
     @ApiProperty()
-    artowrk: Artwork;
+    artwork: Artwork;
 
     @ApiProperty()
     auctionHistories: AuctionHistory[];
+
+    static from(auction: Auction): AuctionDetailDTO {
+        const dto = new AuctionDetailDTO();
+        dto.id = auction.id;
+        dto.artwork = auction.artwork;
+        dto.auctionHistories = auction.auctionHistories;
+        return dto;
+    }
 }

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Artwork } from 'src/artwork/artwork.entity';
+import { Auction } from '../auction.entity';
+
+export class AuctionListItemDTO {
+    constructor(auction: Auction) {
+        this.id = auction.id;
+        this.artwork = auction.artwork;
+    }
+
+    @ApiProperty()
+    id: number;
+
+    @ApiProperty()
+    artwork: Artwork;
+}
+
+export class AuctionDetailDTO {}

--- a/server/src/auction/service/auction.service.ts
+++ b/server/src/auction/service/auction.service.ts
@@ -6,20 +6,20 @@ import { AuctionDetailDTO, AuctionListItemDTO } from '../dto/auctionDTOs';
 export default class AuctionService {
     constructor(private readonly auctionRepository: AuctionRepository) {}
 
-    async getAuctionsWithPageable(page: number): Promise<AuctionListItemDTO[]> {
-        const auctions =
-            await this.auctionRepository.findAllByAuctionWithArtworkAndPageable(
-                page,
-            );
+    async getAuctionsSortedByNewest(page: number): Promise<AuctionListItemDTO[]> {
+        const auctions = await this.auctionRepository.findAllByAuctionOrderByNewest(page);
+
+        return auctions.map(auction => AuctionListItemDTO.from(auction));
+    }
+
+    async getAuctionsSortedByPopular(page: number): Promise<AuctionListItemDTO[]> {
+        const auctions = await this.auctionRepository.findAllByAuctionOrderByPopular(page);
 
         return auctions.map(auction => AuctionListItemDTO.from(auction));
     }
 
     async getAuctionDetail(auctionId: number): Promise<AuctionDetailDTO> {
-        const auction =
-            await this.auctionRepository.findByAuctionWithAuctionHistoryAndArtwork(
-                auctionId,
-            );
+        const auction = await this.auctionRepository.findByAuctionWithAuctionHistoryAndArtwork(auctionId);
 
         return AuctionDetailDTO.from(auction);
     }

--- a/server/src/auction/service/auction.service.ts
+++ b/server/src/auction/service/auction.service.ts
@@ -6,6 +6,11 @@ import { AuctionDetailDTO, AuctionListItemDTO } from '../dto/auctionDTOs';
 export default class AuctionService {
     constructor(private readonly auctionRepository: AuctionRepository) {}
 
+    async getRandomAuctions(): Promise<AuctionListItemDTO[]> {
+        const auctions = await this.auctionRepository.getRandomAuctions();
+        return auctions.map(auction => AuctionListItemDTO.from(auction));
+    }
+
     async getAuctionsSortedByNewest(page: number): Promise<AuctionListItemDTO[]> {
         const auctions = await this.auctionRepository.findAllByAuctionOrderByNewest(page);
 

--- a/server/src/auction/service/auction.service.ts
+++ b/server/src/auction/service/auction.service.ts
@@ -12,7 +12,7 @@ export default class AuctionService {
                 page,
             );
 
-        return auctions.map(auction => new AuctionListItemDTO(auction));
+        return auctions.map(auction => AuctionListItemDTO.from(auction));
     }
 
     async getAuctionDetail(auctionId: number): Promise<AuctionDetailDTO> {
@@ -21,6 +21,6 @@ export default class AuctionService {
                 auctionId,
             );
 
-        return new AuctionDetailDTO(auction);
+        return AuctionDetailDTO.from(auction);
     }
 }

--- a/server/src/auction/service/auction.service.ts
+++ b/server/src/auction/service/auction.service.ts
@@ -7,15 +7,20 @@ export default class AuctionService {
     constructor(private readonly auctionRepository: AuctionRepository) {}
 
     async getAuctionsWithPageable(page: number): Promise<AuctionListItemDTO[]> {
-        const auctions = await this.auctionRepository.getAuctionsWithPageable(
-            page,
-        );
+        const auctions =
+            await this.auctionRepository.findAllByAuctionWithArtworkAndPageable(
+                page,
+            );
 
         return auctions.map(auction => new AuctionListItemDTO(auction));
     }
 
     async getAuctionDetail(auctionId: number): Promise<AuctionDetailDTO> {
-        // @TODO 상세조회
-        return;
+        const auction =
+            await this.auctionRepository.findByAuctionWithAuctionHistoryAndArtwork(
+                auctionId,
+            );
+
+        return new AuctionDetailDTO(auction);
     }
 }

--- a/server/src/auction/service/auction.service.ts
+++ b/server/src/auction/service/auction.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { AuctionRepository } from '../auction.repository';
+import { AuctionDetailDTO, AuctionListItemDTO } from '../dto/auctionDTOs';
+
+@Injectable()
+export default class AuctionService {
+    constructor(private readonly auctionRepository: AuctionRepository) {}
+
+    async getAuctionsWithPageable(page: number): Promise<AuctionListItemDTO[]> {
+        const auctions = await this.auctionRepository.getAuctionsWithPageable(
+            page,
+        );
+
+        return auctions.map(auction => new AuctionListItemDTO(auction));
+    }
+
+    async getAuctionDetail(auctionId: number): Promise<AuctionDetailDTO> {
+        // @TODO 상세조회
+        return;
+    }
+}

--- a/server/src/auction/swagger/index.ts
+++ b/server/src/auction/swagger/index.ts
@@ -1,7 +1,12 @@
 import { ApiOperationOptions } from '@nestjs/swagger';
 
-export const getAuctionsWithInfinityScrollApiOperation: ApiOperationOptions = {
-    summary: '옥션 15개 조회 API - 인피니티 스크롤',
+export const getAuctionsSortedByNewsestApiOperation: ApiOperationOptions = {
+    summary: '옥션 15개 최신순 조회 API - 인피니티 스크롤',
+    description: '현재 경매중인 작품 15개씩 조회하는 API page는 0부터 시작',
+};
+
+export const getAuctionsSortedByPopularApiOperation: ApiOperationOptions = {
+    summary: '옥션 15개 좋아요순 조회 API - 인피니티 스크롤',
     description: '현재 경매중인 작품 15개씩 조회하는 API page는 0부터 시작',
 };
 

--- a/server/src/auction/swagger/index.ts
+++ b/server/src/auction/swagger/index.ts
@@ -1,5 +1,10 @@
 import { ApiOperationOptions } from '@nestjs/swagger';
 
+export const getRandomAuctionsApiOperation: ApiOperationOptions = {
+    summary: '옥션 3개 랜덤 조회 API - 메인페이지용',
+    description: '현재 경매중인 옥션 작품을 3개를 무작위로 골라 리턴하는 api',
+};
+
 export const getAuctionsSortedByNewsestApiOperation: ApiOperationOptions = {
     summary: '옥션 15개 최신순 조회 API - 인피니티 스크롤',
     description: '현재 경매중인 작품 15개씩 조회하는 API page는 0부터 시작',
@@ -12,6 +17,5 @@ export const getAuctionsSortedByPopularApiOperation: ApiOperationOptions = {
 
 export const getAuctionDetailApiOperation: ApiOperationOptions = {
     summary: '옥션 상세 조회 API',
-    description:
-        '작품의 작가 설명, 현재 경매 가격, 가격 변동 추이, 작품 상세정보를 조회합니다.',
+    description: '작품의 작가 설명, 현재 경매 가격, 가격 변동 추이, 작품 상세정보를 조회합니다.',
 };

--- a/server/src/auction/swagger/index.ts
+++ b/server/src/auction/swagger/index.ts
@@ -1,0 +1,12 @@
+import { ApiOperationOptions } from '@nestjs/swagger';
+
+export const getAuctionsWithInfinityScrollApiOperation: ApiOperationOptions = {
+    summary: '옥션 15개 조회 API - 인피니티 스크롤',
+    description: '현재 경매중인 작품 15개씩 조회하는 API page는 0부터 시작',
+};
+
+export const getAuctionDetailApiOperation: ApiOperationOptions = {
+    summary: '옥션 상세 조회 API',
+    description:
+        '작품의 작가 설명, 현재 경매 가격, 가격 변동 추이, 작품 상세정보를 조회합니다.',
+};

--- a/server/src/config/typeorm.config.ts
+++ b/server/src/config/typeorm.config.ts
@@ -11,4 +11,5 @@ export const typeORMConfig: TypeOrmModuleOptions = {
     entities: [__dirname + '/../**/*.entity.{js,ts}'],
     synchronize: process.env.DB_SYNC === 'true' ? true : false,
     namingStrategy: new SnakeNamingStrategy(),
+    logging: true,
 };


### PR DESCRIPTION
### 🔨 작업 내용 설명

옥션 관련 api 기능 개발

### 📑 구현한 내용 목록

- [x] 랜덤 옥션 3개 조회 API - 메인페이지용
- [x] 옥션 최신순 15개씩 리스트 조회 API - 인피니티 스크롤 용
- [x] 옥션 인기순 15개씩 리스트 조회 API - 인피니티 스크롤 용
- [x] 옥션 상세 조회 API - 옥션 상세 페이지용

### 🚧 주의 사항

조인이 너무 많네. 나중에 체크를 해야겠엉..

close #116 
