### PR TITLE
feat: Artwork 입력값 검증 로직 추가- #120

### DIFF
--- a/client/components/Artwork/ArtworkModal/ArtworkFilter.tsx
+++ b/client/components/Artwork/ArtworkModal/ArtworkFilter.tsx
@@ -8,19 +8,19 @@ const ArtworkFilter = ({
     checked: string;
     setChecked: React.Dispatch<string>;
 }) => {
-    const getColor = (checked: string) =>
-        checked === 'artwork'
+    const getColor = (checked: string, current: string) =>
+        checked === current
             ? '/icons/check_green.png'
             : '/icons/check_grey.png';
 
     return (
         <Container>
             <div onClick={() => setChecked('artwork')}>
-                <img src={getColor(checked)} alt="only art work" />
+                <img src={getColor(checked, 'artwork')} alt="only art work" />
                 <span>Only Artwork</span>
             </div>
             <div onClick={() => setChecked('auction')}>
-                <img src={getColor(checked)} alt="also on auction" />
+                <img src={getColor(checked, 'auction')} alt="also on auction" />
                 <span>Also On Auction</span>
             </div>
         </Container>

--- a/client/components/Artwork/ArtworkModal/ArtworkFilter.tsx
+++ b/client/components/Artwork/ArtworkModal/ArtworkFilter.tsx
@@ -8,34 +8,19 @@ const ArtworkFilter = ({
     checked: string;
     setChecked: React.Dispatch<string>;
 }) => {
-    const onClickArtwork = () => {
-        setChecked('artwork');
-    };
-    const onClickAuction = () => {
-        setChecked('auction');
-    };
+    const getColor = (checked: string) =>
+        checked === 'artwork'
+            ? '/icons/check_green.png'
+            : '/icons/check_grey.png';
+
     return (
         <Container>
-            <div onClick={onClickArtwork}>
-                <img
-                    src={
-                        checked === 'artwork'
-                            ? '/icons/check_green.png'
-                            : '/icons/check_grey.png'
-                    }
-                    alt="only art work"
-                />
+            <div onClick={() => setChecked('artwork')}>
+                <img src={getColor(checked)} alt="only art work" />
                 <span>Only Artwork</span>
             </div>
-            <div onClick={onClickAuction}>
-                <img
-                    src={
-                        checked === 'auction'
-                            ? '/icons/check_green.png'
-                            : '/icons/check_grey.png'
-                    }
-                    alt="also on auction"
-                />
+            <div onClick={() => setChecked('auction')}>
+                <img src={getColor(checked)} alt="also on auction" />
                 <span>Also On Auction</span>
             </div>
         </Container>

--- a/client/components/Artwork/ArtworkModal/index.tsx
+++ b/client/components/Artwork/ArtworkModal/index.tsx
@@ -15,42 +15,36 @@ const ArtworkModal = ({
     position,
     setPosition,
 }: ArtworkModalProps) => {
-    const [checked, setChecked] = useState('artwork');
     const modalRef = useRef<HTMLDivElement | null>(null);
-
-    const [descriptionInput, setDescriptionInput] = useState('');
-    const [yearInput, setYearInput] = useState(date.getFullYear().toString());
-    const [bidEndInput, setBidEndIput] = useState('');
-
+    const [checked, setChecked] = useState('artwork');
+    const [description, setDescription] = useState('');
+    const { year, onChangeYear, validateYear } = useInputYear();
+    const { bidEnd, onChangeBidEnd, validateBidEnd } = useInputBidEnd();
+    const { price, onChangePrice, validatePrice } = useInputPrice();
     const onChangeDescription = (e: React.FormEvent) => {
-        setDescriptionInput((e.target as HTMLTextAreaElement).value);
-    };
-
-    const onChangeYear = (e: React.FormEvent) => {
-        setYearInput((e.target as HTMLInputElement).value);
-    };
-
-    const onChangeBidEnd = (e: React.FormEvent) => {
-        setBidEndIput((e.target as HTMLInputElement).value);
+        setDescription((e.target as HTMLTextAreaElement).value);
     };
 
     const onClickConfirm = () => {
         setData({
-            description: descriptionInput,
-            year: yearInput,
-            bidEnd: bidEndInput,
+            description,
+            year,
+            bidEnd: bidEnd ?? '',
         });
         setPosition('-59vh');
     };
 
     return (
         <Modal bottom={position} ref={modalRef}>
-            <ArtworkFilter checked={checked} setChecked={setChecked} />
+            <ArtworkFilter
+                checked={checked}
+                setChecked={(checked) => setChecked(checked)}
+            />
             <Form>
                 <span>Description</span>
                 <textarea
                     cols={10}
-                    value={descriptionInput}
+                    value={description}
                     onChange={onChangeDescription}
                 />
             </Form>
@@ -60,33 +54,88 @@ const ArtworkModal = ({
                         <span>Year</span>
                         <input
                             type="text"
-                            value={yearInput}
+                            value={year}
                             onChange={onChangeYear}
                         />
+                        {!validateYear && <p>input right format</p>}
                     </LightForm>
                     <LightForm>
                         <span>Bid End</span>
                         <input
                             type="text"
-                            value={bidEndInput}
+                            value={bidEnd}
                             onChange={onChangeBidEnd}
                             placeholder="yyyy-mm-dd"
                         />
+                        {!validateBidEnd && <p>input right format</p>}
                     </LightForm>
                     <LightForm>
                         <span>Start Price</span>
-                        <input
-                            type="text"
-                            value={bidEndInput}
-                            onChange={onChangeBidEnd}
-                            placeholder="xxx ETH"
-                        />
+                        <div>
+                            <div>
+                                <input
+                                    type="text"
+                                    value={price ?? 0}
+                                    onChange={onChangePrice}
+                                    placeholder={`${price} ETH`}
+                                />
+                                {!validatePrice && <p>input right format</p>}
+                            </div>
+                            <span>ETH</span>
+                        </div>
                     </LightForm>
                 </>
             )}
             <ConfirmButton onClick={onClickConfirm}>confirm</ConfirmButton>
         </Modal>
     );
+};
+
+const useInputYear = () => {
+    const [year, setYear] = useState(date.getFullYear().toString());
+    const [validateYear, setValidateYear] = useState(true);
+
+    const onChangeYear = (e: React.FormEvent) => {
+        const input = (e.target as HTMLInputElement).value;
+        if (!RegExp(/\d{4}/gi).test(input) && input.length > 0)
+            setValidateYear(false);
+        else setValidateYear(true);
+        setYear(input);
+    };
+
+    return { year, onChangeYear, validateYear };
+};
+
+const useInputBidEnd = () => {
+    const [bidEnd, setBidEnd] = useState('');
+    const [validateBidEnd, setValidateBidEnd] = useState(true);
+
+    const onChangeBidEnd = (e: React.FormEvent) => {
+        const input = (e.target as HTMLInputElement).value;
+        const regex = RegExp(
+            /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/gi,
+        );
+        if (!regex.test(input) && input.length > 0) setValidateBidEnd(false);
+        else setValidateBidEnd(true);
+        setBidEnd(input);
+    };
+
+    return { bidEnd, onChangeBidEnd, validateBidEnd };
+};
+
+const useInputPrice = () => {
+    const [price, setPrice] = useState('0');
+    const [validatePrice, setValidatePrice] = useState(true);
+
+    const onChangePrice = (e: React.FormEvent) => {
+        const input = (e.target as HTMLInputElement).value;
+        const regex = RegExp(/[0-9.]+/gi);
+        if (!regex.test(input) && input.length > 0) setValidatePrice(false);
+        else setValidatePrice(true);
+        setPrice(input);
+    };
+
+    return { price, onChangePrice, validatePrice };
 };
 
 export default ArtworkModal;

--- a/client/components/Artwork/ArtworkModal/style.ts
+++ b/client/components/Artwork/ArtworkModal/style.ts
@@ -52,8 +52,7 @@ export const Form = styled.div`
     }
 
     & span {
-        font-size: 24px;
-        font-weight: 200;
+        font: ${(props) => props.theme.font.textEnMd};
         color: white;
     }
 `;
@@ -61,6 +60,7 @@ export const LightForm = styled(Form)`
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    position: relative;
 
     & input {
         border-radius: 8px;
@@ -73,6 +73,38 @@ export const LightForm = styled(Form)`
 
         &: focus {
             outline: none;
+        }
+    }
+
+    & p {
+        position: absolute;
+        right: 10px;
+        font: ${(props) => props.theme.font.textEnSm};
+        font-size: 14px;
+        color: red;
+    }
+
+    & > div {
+        width: 80%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        color: white;
+        font: ${(props) => props.theme.font.textEnMd};
+
+        & input {
+            width: 90%;
+        }
+
+        & div {
+            width: 100%;
+            position: relative;
+            display: flex;
+            align-items: center;
+
+            & > p {
+                right: 12%;
+            }
         }
     }
 `;

--- a/client/components/Home/Pc/MainAuctionList.tsx
+++ b/client/components/Home/Pc/MainAuctionList.tsx
@@ -19,14 +19,14 @@ const MainAuctionList = ({ AuctionsData }: Props) => {
         <AuctionContainer>
             <p>Auction.</p>
             <AuctionCardContainer>
-                {AuctionsData.map((auction) => {
+                {AuctionsData.map((auction, idx) => {
                     let cardAuction: AuctionCardProps = {
                         ...auction,
                         artist: auction.artist.nickname,
                         price: Number(auction.price),
                     };
                     return (
-                        <Link href={`/auction/${auction.id}`}>
+                        <Link href={`/auction/${auction.id}`} key={idx}>
                             <Card width={'md'} content={cardAuction}></Card>
                         </Link>
                     );

--- a/client/constants/fakeDatas.ts
+++ b/client/constants/fakeDatas.ts
@@ -35,7 +35,7 @@ export const fakeRandomExhibitions: randomExhibitionType[] = [
         title: "Antonio Conte's perfect game",
         artist: { id: 2233, name: 'Conte', nickname: 'ConteIsBack' },
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         startedAt: new Date(),
         endAt: new Date(),
         imgSrc: Fake2.src,
@@ -45,7 +45,7 @@ export const fakeRandomExhibitions: randomExhibitionType[] = [
         title: 'Boostcamp last mission',
         artist: { id: 2233, name: 'JK', nickname: 'JKCrongHonux' },
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         startedAt: new Date(),
         endAt: new Date(),
         imgSrc: Fake3.src,
@@ -55,7 +55,7 @@ export const fakeRandomExhibitions: randomExhibitionType[] = [
         title: 'Tei - 같은 베개',
         artist: { id: 2233, name: 'Tei', nickname: 'same?' },
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         startedAt: new Date(),
         endAt: new Date(),
         imgSrc: Fake4.src,
@@ -65,7 +65,7 @@ export const fakeRandomExhibitions: randomExhibitionType[] = [
         title: '우당탕탕 안테나',
         artist: { id: 2233, name: '유희열', nickname: 'YouHappy' },
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         startedAt: new Date(),
         endAt: new Date(),
         imgSrc: Fake5.src,
@@ -95,7 +95,7 @@ export const fakeRandomAuctions: randomAuctionType[] = [
         type: '사진',
         price: '1.2',
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         status: AUCTION_STATE.OnSale,
         nftToken: 'tokenfake123',
         imgSrc: Fake3.src,
@@ -107,7 +107,7 @@ export const fakeRandomAuctions: randomAuctionType[] = [
         type: '사진',
         price: '1.2',
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         status: AUCTION_STATE.OnSale,
         nftToken: 'tokenfake123',
         imgSrc: Fake5.src,
@@ -119,7 +119,7 @@ export const fakeRandomAuctions: randomAuctionType[] = [
         type: '사진',
         price: '1.2',
         description:
-            'Arsenal were last relegated in 1913 after finishing bottom of the table with 18 points from 38 games. They won just three games all season and lost 23 leaving them five points adrift of 19th-placed Notts County 이력서에 대해 고민 많을거 같아요 ㅎㅎ 내용도 내용이지만 기업에서는 200개가 넘는 이력서를 봐야한다는 점도 고려해보면 좋을거 같아요. 내용을 잘 구성하는 만큼 내용이 상대방에게 잘 전달 되는 것도 중요할수 있어요! 어쨌든 금요일 저녁입니다. 주말 작업이 예정되어 있더라도 조금은 쉬어갈수 있길 바라겠습니다 이력서에 대해 고민 많을거 같아요 ㅎㅎ 내용도 내용이지만 기업에서는 200개가 넘는 이력서를 봐야한다는 점도 고려해보면 좋을거 같아요. 내용을 잘 구성하는 만큼 내용이 상대방에게 잘 전달 되는 것도 중요할수 있어요! 어쨌든 금요일 저녁입니다. 주말 작업이 예정되어 있더라도 조금은 쉬어갈수 있길 바라겠습니다',
+            "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters. 이력서에 대해 고민 많을거 같아요 ㅎㅎ 내용도 내용이지만 기업에서는 200개가 넘는 이력서를 봐야한다는 점도 고려해보면 좋을거 같아요. 내용을 잘 구성하는 만큼 내용이 상대방에게 잘 전달 되는 것도 중요할수 있어요! 어쨌든 금요일 저녁입니다. 주말 작업이 예정되어 있더라도 조금은 쉬어갈수 있길 바라겠습니다 이력서에 대해 고민 많을거 같아요 ㅎㅎ 내용도 내용이지만 기업에서는 200개가 넘는 이력서를 봐야한다는 점도 고려해보면 좋을거 같아요. 내용을 잘 구성하는 만큼 내용이 상대방에게 잘 전달 되는 것도 중요할수 있어요! 어쨌든 금요일 저녁입니다. 주말 작업이 예정되어 있더라도 조금은 쉬어갈수 있길 바라겠습니다",
         status: AUCTION_STATE.OnSale,
         nftToken: 'tokenfake123',
         imgSrc: Fake2.src,

--- a/client/constants/fakeDatas.ts
+++ b/client/constants/fakeDatas.ts
@@ -32,8 +32,8 @@ export const fakeRandomExhibitions: randomExhibitionType[] = [
     },
     {
         id: 2,
-        title: "Antonio Conte's perfect game",
-        artist: { id: 2233, name: 'Conte', nickname: 'ConteIsBack' },
+        title: 'Come back Nuno',
+        artist: { id: 2233, name: 'Nuno', nickname: 'ConteSucks' },
         description:
             "In 2001, Campbell joined Tottenham's North London rivals Arsenal on a free transfer, and as a result has remained a deeply unpopular figure amongst Spurs supporters.",
         startedAt: new Date(),

--- a/client/hooks/useInputArtwork.ts
+++ b/client/hooks/useInputArtwork.ts
@@ -13,7 +13,10 @@ const useInputArtwork = (image: File) => {
 
     const onClickDone = async () => {
         const formData = new FormData();
-        formData.append('title', titleInput);
+        formData.append(
+            'title',
+            titleInput.length === 0 ? 'Untitled' : titleInput,
+        );
         formData.append('type', typeInput);
         formData.append('description', modalInputData['description']);
         formData.append('year', modalInputData['year']);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "client",
             "version": "0.1.0",
             "dependencies": {
                 "@emotion/react": "^11.5.0",
@@ -1273,6 +1272,7 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -3429,6 +3429,10 @@
                 "@next/polyfill-module": "11.1.2",
                 "@next/react-dev-overlay": "11.1.2",
                 "@next/react-refresh-utils": "11.1.2",
+                "@next/swc-darwin-arm64": "11.1.2",
+                "@next/swc-darwin-x64": "11.1.2",
+                "@next/swc-linux-x64-gnu": "11.1.2",
+                "@next/swc-win32-x64-msvc": "11.1.2",
                 "@node-rs/helper": "1.2.1",
                 "assert": "2.0.0",
                 "ast-types": "0.13.2",


### PR DESCRIPTION
### 🔨 작업 내용 설명

아트워크 등록 모달에서 입력된 값 검증하는 로직을 추가했습니다.

### 📑 구현한 내용 목록

- [x] 이상한 정보를 솔 캠벨이 누구인지에 대한 설명으로 교체
- [x] 누누는 명장이었다
- [x] 연도, 경매종료날짜, 시작가격 입력 시 검증 로직 추가

### 🚧 주의 사항

### 🖥 스크린 샷
![스크린샷 2021-11-08 오후 5 34 08](https://user-images.githubusercontent.com/53335940/140709389-af34697b-79cf-46d8-a1ac-528b2edf3f05.png)

close #120 
