### PR TITLE
feat: sql generator 생성 - #124

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 node_modules
 client/.next
+
+output.sql

--- a/sqlGenerator/index.js
+++ b/sqlGenerator/index.js
@@ -32,7 +32,7 @@ function user(number) {
   let result = ["\n-- user sql"];
   for (let i = 0; i < number; i++) {
     result.push(`INSERT INTO \`${schemaName}\`.\`user\` 
-        (\`id\`, \`user_id\`, \`nickname\`, \`sns_id\`, \`description\`, \`avatar\`, \`refresh_token\`, \`login_strategy\`) 
+        (\`id\`, \`user_id\`, \`name\`, \`sns_id\`, \`description\`, \`avatar\`, \`refresh_token\`, \`login_strategy\`) 
         VALUES ('${
           i + 1
         }', '${faker.internet.email()}', '${faker.internet.userName()}', '${faker.lorem.sentence()}', '${faker.lorem.sentence()}', '${faker.internet.avatar()}', '${faker.lorem.sentence()}', '${
@@ -96,10 +96,10 @@ function acution(number) {
     isAuctionSelect.delete(artworkIndex - 1);
 
     result.push(`INSERT INTO \`${schemaName}\`.\`auction\`  
-        (\`id\`, \`start_at\`, \`seller_id\`, \`artwork_id\`) 
+        (\`id\`, \`start_at\`, \`end_at\` \`seller_id\`, \`artwork_id\`) 
         VALUES ('${i + 1}', CURRENT_DATE, CURRENT_DATE + ${
       randomInt(10) + 1
-    }, '${userIndex}');
+    }, '${userIndex}', '${artworkIndex}');
         `);
     result.push(
       `UPDATE \`${schemaName}\`.\`artwork\` SET \`status\` = 'InBid' WHERE (\`id\` = '${artworkIndex}');`

--- a/sqlGenerator/index.js
+++ b/sqlGenerator/index.js
@@ -1,0 +1,151 @@
+const fs = require("fs");
+const faker = require("faker");
+const { randomInt } = require("crypto");
+
+const MAX = 99999;
+
+const schemaName = "salon";
+const strategy = ["google", "kakao"];
+
+const types = ["사진", "그림", "디지털 아트"];
+// const status = ["NoBid", "InBid"];
+const images = [
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359411799-test.jpg",
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359420039-test2.png",
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359435107-test3.png",
+];
+const cropped_image = [
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359411801-test.jpg",
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359420041-test2.png",
+  "https://salon-bucket.kr.object.ncloudstorage.com/objects/1636359435110-test3.png",
+];
+
+let isExhibitionSelect;
+let isAuctionSelect;
+
+let userCount;
+let artworkCount;
+let exhibitionCount;
+let auctionCount;
+
+function user(number) {
+  let result = ["\n-- user sql"];
+  for (let i = 0; i < number; i++) {
+    result.push(`INSERT INTO \`${schemaName}\`.\`user\` 
+        (\`id\`, \`user_id\`, \`nickname\`, \`sns_id\`, \`description\`, \`avatar\`, \`refresh_token\`, \`login_strategy\`) 
+        VALUES ('${
+          i + 1
+        }', '${faker.internet.email()}', '${faker.internet.userName()}', '${faker.lorem.sentence()}', '${faker.lorem.sentence()}', '${faker.internet.avatar()}', '${faker.lorem.sentence()}', '${
+      strategy[randomInt(MAX) % strategy.length]
+    }');`);
+  }
+  return result.join("\n");
+}
+
+function exhibition(number) {
+  let result = ["\n-- exhibition sql"];
+
+  let artworkIndex = 0;
+  isExhibitionSelect = Array(artworkCount).fill(undefined);
+
+  for (let i = 0; i < number; i++) {
+    const userIndex = randomInt(userCount) + 1;
+    const selectCount = randomInt(5);
+    result.push(`INSERT INTO \`${schemaName}\`.\`exhibition\` 
+      (\`id\`, \`collaborator\`, \`title\`, \`description\`, \`thumbnail_image\`, \`artist_id\`, \`start_at\`, \`end_at\`)
+      VALUES ('${
+        i + 1
+      }', '${faker.internet.userName()}', '${faker.lorem.sentence()}', '${faker.lorem.sentence()}', '${
+      images[randomInt(cropped_image.length)]
+    }', '${userIndex}', CURRENT_DATE, CURRENT_DATE + ${randomInt(10) + 1});`);
+
+    for (let j = 0; j < selectCount && artworkIndex < artworkCount; j++) {
+      isExhibitionSelect[artworkIndex++] = i + 1;
+    }
+  }
+  return result.join("\n");
+}
+
+function artwork(number) {
+  let result = ["\n-- artwork sql"];
+  for (let i = 0; i < number; i++) {
+    const userIndex = randomInt(userCount) + 1;
+    const selectImage = randomInt(images.length);
+    result.push(`INSERT INTO \`${schemaName}\`.\`artwork\` 
+    (\`id\`, \`title\`, \`type\`, \`price\`, \`description\`, \`status\`, \`nft_token\`, \`exhibition_id\`,\`artist_id\`, \`owner_id\`, \`original_image\`, \`cropped_image\`)
+    VALUES ('${i + 1}', '${faker.lorem.word()}', '${
+      types[randomInt(types.length)]
+    }', '${
+      randomInt(100) / 100
+    }', '${faker.lorem.sentence()}', 'NoBid', '${faker.lorem.sentence()}', ${
+      isExhibitionSelect[i] ? `'${isExhibitionSelect[i]}'` : "null"
+    },'${userIndex}', '${userIndex}', '${images[selectImage]}', '${
+      cropped_image[selectImage]
+    }');`);
+  }
+  return result.join("\n");
+}
+
+function acution(number) {
+  let result = ["\n-- auction sql"];
+  isAuctionSelect = new Set(Array(artworkCount).keys());
+
+  for (let i = 0; i < number; i++) {
+    const userIndex = randomInt(userCount) + 1;
+    const artworkIndex = getRandomKey(isAuctionSelect) + 1;
+    isAuctionSelect.delete(artworkIndex - 1);
+
+    result.push(`INSERT INTO \`${schemaName}\`.\`auction\`  
+        (\`id\`, \`start_at\`, \`seller_id\`, \`artwork_id\`) 
+        VALUES ('${i + 1}', CURRENT_DATE, CURRENT_DATE + ${
+      randomInt(10) + 1
+    }, '${userIndex}');
+        `);
+    result.push(
+      `UPDATE \`${schemaName}\`.\`artwork\` SET \`status\` = 'InBid' WHERE (\`id\` = '${artworkIndex}');`
+    );
+  }
+  return result.join("\n");
+}
+
+function getRandomKey(collection) {
+  let keys = Array.from(collection.keys());
+  return keys[randomInt(keys.length)];
+}
+
+function generate(argv) {
+  const outputFile = fs.createWriteStream("output.sql");
+
+  outputFile.once("open", function (fd) {
+    const userIndex = argv.indexOf("user");
+    const artworkIndex = argv.indexOf("artwork");
+    const exhibitionIndex = argv.indexOf("exhibition");
+    const auctionIndex = argv.indexOf("auction");
+    userCount = Number(argv[userIndex + 1]);
+    exhibitionCount = Number(argv[exhibitionIndex + 1]);
+    artworkCount = Number(argv[artworkIndex + 1]);
+    auctionCount = Number(argv[auctionIndex + 1]);
+
+    if (userIndex !== -1) {
+      outputFile.write(user(userCount));
+    }
+    if (exhibitionIndex !== -1) {
+      outputFile.write("\n\n");
+      outputFile.write(exhibition(exhibitionCount));
+    }
+
+    if (artworkIndex !== -1) {
+      outputFile.write("\n\n");
+      outputFile.write(artwork(artworkCount));
+    }
+
+    if (auctionIndex !== -1) {
+      outputFile.write("\n\n");
+      outputFile.write(acution(auctionCount));
+    }
+
+    outputFile.end();
+  });
+}
+
+generate(process.argv);

--- a/sqlGenerator/index.js
+++ b/sqlGenerator/index.js
@@ -4,7 +4,7 @@ const { randomInt } = require("crypto");
 
 const MAX = 99999;
 
-const schemaName = "salon";
+const schemaName = process.argv[2];
 const strategy = ["google", "kakao"];
 
 const types = ["사진", "그림", "디지털 아트"];

--- a/sqlGenerator/package-lock.json
+++ b/sqlGenerator/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "sqlgenerator",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sqlgenerator",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "faker": "^5.5.3"
+      }
+    },
+    "node_modules/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
+    }
+  },
+  "dependencies": {
+    "faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
+    }
+  }
+}

--- a/sqlGenerator/package.json
+++ b/sqlGenerator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sqlgenerator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "faker": "^5.5.3"
+  }
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명

- 테스트 용으로 사용할 제너레이터 생성
- node index.js salon user 5 artwork 10 exhibition 5 auction 10  이런 식으로 쓰면됨.
- node index.js <데이터베이스 이름> <테이블이름> <생성할 sql 개수> ... ;
### 📑 구현한 내용 목록

- [x] user sql
- [x] artwork sql
- [x] exhibition sql
- [x] auction sql
- [ ] auction history 

### 🚧 주의 사항
- auction수가 artwork 수보다 작을 수 없음.

### 🖥 스크린 샷

![image](https://user-images.githubusercontent.com/15667978/140719265-53577e01-c458-41ff-9017-be592375a687.png)

close #124
