### PR TITLE
feat: exhibition 리스트 페이지 API 연결(필터), 잡다한 수정

### DIFF
--- a/client/components/Artwork/Uploader/index.tsx
+++ b/client/components/Artwork/Uploader/index.tsx
@@ -54,6 +54,7 @@ const FileInput = styled.div`
     height: 100px;
     border: 1px dashed black;
     margin-bottom: 20px;
+    cursor: pointer;
 
     & > input {
         position: absolute;

--- a/client/components/Auction/AuctionList.tsx
+++ b/client/components/Auction/AuctionList.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import Link from 'next/link';
+
 import { Button, Center } from '@styles/common';
 import { AuctionCardProps } from '@const/card-type';
 import Card from '@components/Card';
+import { Filter } from 'pages/exhibition/style';
 
 const DUMMY_DATA: Array<AuctionCardProps> = [
     {
@@ -65,6 +67,12 @@ const DUMMY_DATA: Array<AuctionCardProps> = [
 ];
 
 const AuctionList = () => {
+    const [onSelect, setOnSelect] = useState('Popular');
+
+    const onClickFilter = ({ currentTarget }: React.MouseEvent) => {
+        setOnSelect(currentTarget.textContent || 'Newest');
+    };
+
     return (
         <Container>
             <Title>
@@ -73,6 +81,24 @@ const AuctionList = () => {
                     <BlackButton>Post Artwork</BlackButton>
                 </Link>
             </Title>
+            <FilterWrapper>
+                <div>
+                    <Filter
+                        onClick={onClickFilter}
+                        select={onSelect === 'Popular'}
+                    >
+                        Popular
+                    </Filter>
+                </div>
+                <div>
+                    <Filter
+                        onClick={onClickFilter}
+                        select={onSelect === 'Newest'}
+                    >
+                        Newest
+                    </Filter>
+                </div>
+            </FilterWrapper>
             <Grid>
                 {DUMMY_DATA.map((item) => {
                     return <Card width="lg" content={item} />;
@@ -94,7 +120,7 @@ const Title = styled.div`
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    margin-bottom: 30px;
+    margin-bottom: 10px;
 
     & h1 {
         font: ${(props) => props.theme.font.textXl};
@@ -111,6 +137,31 @@ const Grid = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     gap: 50px;
+    margin-bottom: 45px;
+`;
+
+const FilterWrapper = styled.div`
+    margin-bottom: 50px;
+    align-self: flex-start;
+    display: flex;
+    justify-content: space-between;
+
+    & div {
+        border-left: 1px solid ${(props) => props.theme.color.placeholder};
+    }
+
+    & > div:first-of-type {
+        border: none;
+        & button {
+            margin-left: 0;
+            margin-right: 30px;
+        }
+    }
+
+    & button {
+        margin: 0 30px 0 30px;
+        box-sizing: content-box;
+    }
 `;
 
 export default AuctionList;

--- a/client/components/Auction/AuctionList.tsx
+++ b/client/components/Auction/AuctionList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import Link from 'next/link';
 
@@ -68,6 +68,12 @@ const DUMMY_DATA: Array<AuctionCardProps> = [
 
 const AuctionList = () => {
     const [onSelect, setOnSelect] = useState('Popular');
+    const [auctionItems, setAuctionItems] = useState<AuctionCardProps[]>([]);
+    const [page, setPage] = useState(1);
+
+    useEffect(() => {
+        // TODO : 경매 아이템 리스트 가져오는 api 추가
+    }, [onSelect, page]);
 
     const onClickFilter = ({ currentTarget }: React.MouseEvent) => {
         setOnSelect(currentTarget.textContent || 'Newest');

--- a/client/components/Card/style.ts
+++ b/client/components/Card/style.ts
@@ -47,10 +47,11 @@ export const BlurFull = styled.div`
     @keyframes growblur {
         0% {
             backdrop-filter: blur(4px);
+            background: rgba(0, 0, 0, 0);
         }
         100% {
             backdrop-filter: blur(20px);
-            box-shadow: 3px 5px 5px rgba(0, 0, 0, 0.3);
+            background: rgba(0, 0, 0, 0.4);
         }
     }
 `;

--- a/client/components/Header/headerStyles.tsx
+++ b/client/components/Header/headerStyles.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { NavButton, RightContainer, SearchBarContainer } from './style';
 import ProfilePic from '@assets/images/profile.png';
-import { useState } from 'react';
+import parseCookie from '@utils/parseCookie';
 
 export const defaultHeader = () => {
+    const [session, setSession] = useState(false);
+    useEffect(() => {
+        const isLoggedIn = parseCookie()('accessToken') ? true : false;
+        setSession(isLoggedIn);
+    }, []);
+
     return (
         <RightContainer>
             <Link href="/exhibition">
@@ -15,8 +21,11 @@ export const defaultHeader = () => {
             </Link>
             <Link href="/login">
                 <NavButton>
-                    {/* if isLogindata ? imagedata : profilePic.src */}
-                    <img src={ProfilePic.src} alt="profile" />
+                    {session ? (
+                        <img src={ProfilePic.src} alt="profile" />
+                    ) : (
+                        'LogIn'
+                    )}
                 </NavButton>
             </Link>
         </RightContainer>

--- a/client/pages/exhibition/index.tsx
+++ b/client/pages/exhibition/index.tsx
@@ -1,11 +1,17 @@
 import React, { useState } from 'react';
 import type { NextPage } from 'next';
-import styled from '@emotion/styled';
-import { Button, SpaceBetween } from '@styles/common';
 import Layout from '@components/common/Layout';
 import { ExhibitionCardProps } from '@const/card-type';
 import Card from '@components/Card';
 import Link from 'next/link';
+import {
+    TopContainer,
+    FilterWrapper,
+    Filter,
+    Buttons,
+    BlackButton,
+    ExhibitionList,
+} from './style';
 
 const dummyExihibition: ExhibitionCardProps[] = [
     {
@@ -134,69 +140,8 @@ const ExhibitionPage: NextPage = () => {
     );
 };
 
-interface FilterProps {
+export interface FilterProps {
     select: boolean;
 }
-
-const TopContainer = styled.div`
-    display: flex;
-    width: 1180px;
-    margin: 45px 0;
-`;
-
-const FilterWrapper = styled.div`
-    ${SpaceBetween}
-
-    & > div {
-        border-left: 1px solid #a6a6a6;
-    }
-
-    & > div:first-of-type {
-        border-left: none;
-    }
-`;
-
-const Filter = styled.button<FilterProps>`
-    height: 30px;
-    margin: 0px 30px;
-    border: none;
-    background: none;
-
-    font: ${(props) => props.theme.font.textEnMd};
-    border-bottom: ${(props) =>
-        props.select ? `1px solid ${props.theme.color.primary}` : ''};
-    color: ${(props) =>
-        props.select
-            ? props.theme.color.primary
-            : props.theme.color.placeholder};
-    &:hover {
-        color: ${(props) => props.theme.color.primary};
-    }
-`;
-
-const Buttons = styled.div`
-    margin-left: auto;
-`;
-
-const BlackButton = styled(Button)`
-    color: black;
-    border-bottom: 1px solid black;
-    font: ${(props) => props.theme.font.textEnLg};
-
-    &:first-of-type {
-        margin-right: 25px;
-    }
-`;
-
-const ExhibitionList = styled.div`
-    ${SpaceBetween}
-    flex-wrap: wrap;
-
-    width: 1180px;
-
-    & > div {
-        margin-bottom: 45px;
-    }
-`;
 
 export default ExhibitionPage;

--- a/client/pages/exhibition/index.tsx
+++ b/client/pages/exhibition/index.tsx
@@ -87,24 +87,30 @@ const ExhibitionPage: NextPage = () => {
         <Layout>
             <TopContainer>
                 <FilterWrapper>
-                    <Filter
-                        select={onSelect === 'Newest'}
-                        onClick={onSelectFilter}
-                    >
-                        Newest
-                    </Filter>
-                    <Filter
-                        select={onSelect === 'Popular'}
-                        onClick={onSelectFilter}
-                    >
-                        Popular
-                    </Filter>
-                    <Filter
-                        select={onSelect === 'Deadline'}
-                        onClick={onSelectFilter}
-                    >
-                        Deadline
-                    </Filter>
+                    <div>
+                        <Filter
+                            select={onSelect === 'Newest'}
+                            onClick={onSelectFilter}
+                        >
+                            Newest
+                        </Filter>
+                    </div>
+                    <div>
+                        <Filter
+                            select={onSelect === 'Popular'}
+                            onClick={onSelectFilter}
+                        >
+                            Popular
+                        </Filter>
+                    </div>
+                    <div>
+                        <Filter
+                            select={onSelect === 'Deadline'}
+                            onClick={onSelectFilter}
+                        >
+                            Deadline
+                        </Filter>
+                    </div>
                 </FilterWrapper>
 
                 <Buttons>
@@ -140,22 +146,31 @@ const TopContainer = styled.div`
 
 const FilterWrapper = styled.div`
     ${SpaceBetween}
+
+    & > div {
+        border-left: 1px solid #a6a6a6;
+    }
+
+    & > div:first-of-type {
+        border-left: none;
+    }
 `;
 
 const Filter = styled.button<FilterProps>`
     height: 30px;
-    padding: 0px 30px;
+    margin: 0px 30px;
     border: none;
-    border-left: 1px solid #a6a6a6;
-
-    font: ${(props) =>
-        props.select ? props.theme.font.textEnLg : props.theme.font.textEnMd};
-    color: ${(props) => (props.select ? props.theme.color.primary : '#757575')};
-
     background: none;
 
-    &:first-of-type {
-        border-left: none;
+    font: ${(props) => props.theme.font.textEnMd};
+    border-bottom: ${(props) =>
+        props.select ? `1px solid ${props.theme.color.primary}` : ''};
+    color: ${(props) =>
+        props.select
+            ? props.theme.color.primary
+            : props.theme.color.placeholder};
+    &:hover {
+        color: ${(props) => props.theme.color.primary};
     }
 `;
 

--- a/client/pages/exhibition/index.tsx
+++ b/client/pages/exhibition/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import type { NextPage } from 'next';
+
 import Layout from '@components/common/Layout';
 import { ExhibitionCardProps } from '@const/card-type';
 import Card from '@components/Card';
@@ -12,7 +13,7 @@ import {
     BlackButton,
     ExhibitionList,
 } from './style';
-
+import { getExhibitions } from '@utils/networking';
 const dummyExihibition: ExhibitionCardProps[] = [
     {
         id: 1,
@@ -84,6 +85,14 @@ const dummyExihibition: ExhibitionCardProps[] = [
 
 const ExhibitionPage: NextPage = () => {
     const [onSelect, setOnSelect] = useState<string>('Newest');
+    const [exhibitions, setExhibitions] = useState<ExhibitionCardProps[]>([]);
+    const [page, setPage] = useState(1);
+
+    useEffect(() => {
+        getExhibitions(onSelect.toLowerCase(), page).then((res) =>
+            setExhibitions([...exhibitions, ...res.data]),
+        );
+    }, [onSelect, page]);
 
     const onSelectFilter = ({ currentTarget }: React.MouseEvent) => {
         setOnSelect(currentTarget.textContent || 'Newest');

--- a/client/pages/exhibition/index.tsx
+++ b/client/pages/exhibition/index.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { NextPage } from 'next';
+import Link from 'next/link';
 
 import Layout from '@components/common/Layout';
-import { ExhibitionCardProps } from '@const/card-type';
 import Card from '@components/Card';
-import Link from 'next/link';
 import {
     TopContainer,
     FilterWrapper,
@@ -13,75 +12,76 @@ import {
     BlackButton,
     ExhibitionList,
 } from './style';
+import { ExhibitionCardProps } from '@const/card-type';
 import { getExhibitions } from '@utils/networking';
-const dummyExihibition: ExhibitionCardProps[] = [
-    {
-        id: 1,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-    {
-        id: 2,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-    {
-        id: 3,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-    {
-        id: 4,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-    {
-        id: 5,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-    {
-        id: 6,
-        title: '제목',
-        description: '설명',
-        artist: '작가',
-        imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
-        category: '사진',
-        theme: '부스트캠프',
-        artCount: 3,
-        isSale: true,
-    },
-];
+// const dummyExihibition: ExhibitionCardProps[] = [
+//     {
+//         id: 1,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+//     {
+//         id: 2,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+//     {
+//         id: 3,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+//     {
+//         id: 4,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/BS-RVzJM5otwbPEtfNwM2uQY0n8hc37CNGiSLVGHKrlZzZej3flmJ1GlzYD7gWzGXYzuvtU053yfPYPyEcAFzsB5OdRBw0Ruyy0u=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+//     {
+//         id: 5,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/d2Df1yJtBUGvtcU85joQlgmAYkfNgOzY5rx6FbplJ91xvLbBiPmIt5qRlQBtSHkh2lKfAQuUVE4k2m34sywuwT-DZXKPRYoZfdiFlA=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+//     {
+//         id: 6,
+//         title: '제목',
+//         description: '설명',
+//         artist: '작가',
+//         imgSrc: 'https://lh3.googleusercontent.com/O7OdPM5UVc97cWRDvGIHg8hTqireb0YTA7ocwpz8fvWb4xgrFFt5x391saO27hzp0PwLRcTseEPLSgolpYQNgRWm8egseUI_33fZOg=w600',
+//         category: '사진',
+//         theme: '부스트캠프',
+//         artCount: 3,
+//         isSale: true,
+//     },
+// ];
 
 const ExhibitionPage: NextPage = () => {
     const [onSelect, setOnSelect] = useState<string>('Newest');
@@ -94,7 +94,7 @@ const ExhibitionPage: NextPage = () => {
         );
     }, [onSelect, page]);
 
-    const onSelectFilter = ({ currentTarget }: React.MouseEvent) => {
+    const onClickFilter = ({ currentTarget }: React.MouseEvent) => {
         setOnSelect(currentTarget.textContent || 'Newest');
     };
 
@@ -105,7 +105,7 @@ const ExhibitionPage: NextPage = () => {
                     <div>
                         <Filter
                             select={onSelect === 'Newest'}
-                            onClick={onSelectFilter}
+                            onClick={onClickFilter}
                         >
                             Newest
                         </Filter>
@@ -113,7 +113,7 @@ const ExhibitionPage: NextPage = () => {
                     <div>
                         <Filter
                             select={onSelect === 'Popular'}
-                            onClick={onSelectFilter}
+                            onClick={onClickFilter}
                         >
                             Popular
                         </Filter>
@@ -121,7 +121,7 @@ const ExhibitionPage: NextPage = () => {
                     <div>
                         <Filter
                             select={onSelect === 'Deadline'}
-                            onClick={onSelectFilter}
+                            onClick={onClickFilter}
                         >
                             Deadline
                         </Filter>
@@ -137,7 +137,7 @@ const ExhibitionPage: NextPage = () => {
             </TopContainer>
 
             <ExhibitionList>
-                {dummyExihibition.map((exihibition) => (
+                {exhibitions.map((exihibition) => (
                     <Card
                         key={exihibition.id}
                         width="lg"

--- a/client/pages/exhibition/style.ts
+++ b/client/pages/exhibition/style.ts
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+import { Button, SpaceBetween } from '@styles/common';
+import { FilterProps } from './index';
+
+export const TopContainer = styled.div`
+    display: flex;
+    width: 1180px;
+    margin: 45px 0;
+`;
+export const FilterWrapper = styled.div`
+    ${SpaceBetween}
+
+    & > div {
+        border-left: 1px solid #a6a6a6;
+    }
+
+    & > div:first-of-type {
+        border-left: none;
+    }
+`;
+export const Filter = styled.button<FilterProps>`
+    height: 30px;
+    margin: 0px 30px;
+    border: none;
+    background: none;
+
+    font: ${(props) => props.theme.font.textEnMd};
+    border-bottom: ${(props) =>
+        props.select ? `1px solid ${props.theme.color.primary}` : ''};
+    color: ${(props) =>
+        props.select
+            ? props.theme.color.primary
+            : props.theme.color.placeholder};
+    &:hover {
+        color: ${(props) => props.theme.color.primary};
+    }
+`;
+export const Buttons = styled.div`
+    margin-left: auto;
+`;
+export const BlackButton = styled(Button)`
+    color: black;
+    border-bottom: 1px solid black;
+    font: ${(props) => props.theme.font.textEnLg};
+
+    &:first-of-type {
+        margin-right: 25px;
+    }
+`;
+export const ExhibitionList = styled.div`
+    ${SpaceBetween}
+    flex-wrap: wrap;
+
+    width: 1180px;
+
+    & > div {
+        margin-bottom: 45px;
+    }
+`;

--- a/client/pages/login/index.tsx
+++ b/client/pages/login/index.tsx
@@ -75,6 +75,7 @@ const Logo = styled.div`
     top: 20px;
     left: 20px;
     z-index: 500;
+    cursor: pointer;
 
     & img {
         height: 40px;

--- a/client/utils/networking.ts
+++ b/client/utils/networking.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { Artwork, PostArtworkResponse } from 'interfaces';
+import { ExhibitionCardProps } from '@const/card-type';
 
 const API_SERVER_URL = process.env.API_SERVER_URL;
 
@@ -35,6 +36,12 @@ export const getRandomExhibitions = () => {
     return axios.get(`${API_SERVER_URL}/exhibitions/random`);
 };
 
+export const getExhibitions = (filter: string, page: number) => {
+    return axios.get(`${API_SERVER_URL}/exhibitions/${filter}?page=${page}`);
+};
+
 export const getRandomAuctions = () => {
-    return axios.get(`${API_SERVER_URL}/art-works/random?status=onSale`);
+    return axios.get<ExhibitionCardProps[]>(
+        `${API_SERVER_URL}/art-works/random?status=onSale`,
+    );
 };

--- a/client/utils/parseCookie.ts
+++ b/client/utils/parseCookie.ts
@@ -2,7 +2,7 @@ const parseCookie = () => {
     let cookieObject: { [key: string]: string } = {};
     document.cookie.split(/;/gi).forEach((str: string) => {
         const [key, value] = str.split('=');
-        cookieObject[key.trim()] = value.trim();
+        cookieObject[key.trim()] = value?.trim();
     });
 
     return (key: string): string | undefined => {


### PR DESCRIPTION
### 🔨 작업 내용 설명

스크럼에서 얘기 나온 사항들 주로 반영하고 API 연결했습니다.

### 📑 구현한 내용 목록

- [x] 카드 컴포넌트 호버 시 점진적으로 어두워지도록 애니메이션 수정
- [x] exhibition 리스트 페이지 필터 스타일 수정 및 스타일 파일 별도로 분리
- [x] 구현된 API에 따라 필터 작동하도록 로직 추가
- [x] 헤더의 Avatar 아이콘 로그인 안했을 시 'Login' 버튼으로 변경

### 🚧 주의 사항


### 🖥 스크린 샷


close #121 
