### PR TITLE
fix: 경매 작품, 전시회 DTO 개선 및 메인 페이지 API 연동 부분 개선 - #145

### DIFF
--- a/client/components/Auction/AuctionList.tsx
+++ b/client/components/Auction/AuctionList.tsx
@@ -13,7 +13,7 @@ import useHandleRequireLoginModal from '@hooks/useHandleRequireLoginModal';
 const AuctionList = () => {
     const [onSelect, setOnSelect] = useState('Popular');
     const [auctionItems, setAuctionItems] = useState<AuctionCardProps[]>([]);
-    const [page, setPage] = useState(1);
+    const [page, setPage] = useState(0);
     const {
         accessToken,
         requireLoginModal,

--- a/client/components/Home/Pc/MainAuctionList.tsx
+++ b/client/components/Home/Pc/MainAuctionList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
 
-import { randomAuctionType } from 'constants/fakeDatas';
 import {
     AuctionContainer,
     AuctionCardContainer,
@@ -12,26 +11,17 @@ import { AuctionCardProps } from '@const/card-type';
 import { BlackButton } from '@styles/common';
 
 interface Props {
-    AuctionsData: randomAuctionType[];
+    AuctionsData: AuctionCardProps[];
 }
-
-const AuctionCardGenerator = ({ auction }: { auction: randomAuctionType }) => {
-    let cardAuction: AuctionCardProps = {
-        ...auction,
-        artist: auction.artist.nickname,
-        price: Number(auction.price),
-    };
-    return <Card width={'md'} content={cardAuction} key={auction.id}></Card>;
-};
 
 const MainAuctionList = ({ AuctionsData }: Props) => {
     return (
         <AuctionContainer>
             <p>Auction.</p>
             <AuctionCardContainer>
-                {AuctionsData.map((auction) => {
-                    <AuctionCardGenerator auction={auction} />;
-                })}
+                {AuctionsData.map((auction) =>
+                    <Card width={'md'} content={auction} key={auction.id}/>
+                )}
             </AuctionCardContainer>
             <Link href="/auction">
                 <MoreButtonContainer>

--- a/client/components/Home/Pc/MainCarousel.tsx
+++ b/client/components/Home/Pc/MainCarousel.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
-import { randomExhibitionType } from 'constants/fakeDatas';
 import {
     CarouselSlider,
     SlideWrapper,
@@ -17,9 +16,10 @@ import {
 } from './styles';
 import { setColorFromImage } from '@utils/setColorFromImage';
 import { BlackButton } from '@styles/common';
+import { ExhibitionCardProps } from '@const/card-type';
 
 interface Props {
-    ExhibitionsData: randomExhibitionType[];
+    ExhibitionsData: ExhibitionCardProps[];
 }
 
 const MainCarousel = ({ ExhibitionsData }: Props) => {
@@ -71,7 +71,7 @@ const MainCarousel = ({ ExhibitionsData }: Props) => {
                                                 {exhibition.title}
                                             </InfoTitle>
                                             <InfoDescription>
-                                                {exhibition.artist.name}
+                                                {exhibition.artist}
                                             </InfoDescription>
                                             <InfoDescription>
                                                 {exhibition.description}

--- a/client/components/Home/Pc/index.tsx
+++ b/client/components/Home/Pc/index.tsx
@@ -3,26 +3,15 @@ import Head from 'next/head';
 import Layout from '@components/common/Layout';
 import MainCarousel from './MainCarousel';
 import MainAuctionList from './MainAuctionList';
-import {
-    randomAuctionType,
-    randomExhibitionType,
-    fakeRandomExhibitions,
-} from 'constants/fakeDatas';
 import NftInfo from './NftInfo';
+import { AuctionCardProps, ExhibitionCardProps } from '@const/card-type';
 
 interface Props {
-    ExhibitionsData: string[];
-    AuctionsData: string[];
+    ExhibitionsData: ExhibitionCardProps[];
+    AuctionsData: AuctionCardProps[];
 }
 const Pc = (props: Props) => {
-    let ExhibitionsData = props.ExhibitionsData.map((exhibition: string) =>
-        JSON.parse(exhibition),
-    ) as randomExhibitionType[];
-    const AuctionsData = props.AuctionsData.map((auction: string) =>
-        JSON.parse(auction),
-    ) as randomAuctionType[];
-    //테스트용! 데이터셋이 준비될때까지 이거로
-    if (!ExhibitionsData.length) ExhibitionsData = fakeRandomExhibitions;
+    const { ExhibitionsData, AuctionsData } = props;
 
     return (
         <>

--- a/client/components/Home/Pc/styles.ts
+++ b/client/components/Home/Pc/styles.ts
@@ -126,8 +126,8 @@ export const AuctionContainer = styled.div`
     }
 `;
 export const AuctionCardContainer = styled.div`
-    width: 100%;
-    margin-top: 50px;
+    width: 1180px;
+    margin: 50px auto 0 auto;
     ${SpaceBetween};
 `;
 

--- a/client/components/common/Layout.tsx
+++ b/client/components/common/Layout.tsx
@@ -27,6 +27,7 @@ const Body = styled.div<{ horizontal?: boolean }>`
     ${(props) =>
         props.horizontal ? 'flex-direction: row;' : 'flex-direction: column;'}
     min-height: calc(100vh - 270px);
+    overflow-x: hidden;
 `;
 
 export default Layout;

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -5,15 +5,11 @@ import Mobile from '@components/Home/Mobile';
 import Pc from '@components/Home/Pc';
 import { isMobile } from 'utils/isMobile';
 import { getRandomAuctions, getRandomExhibitions } from 'utils/networking';
-import {
-    fakeRandomAuctions,
-    randomAuctionType,
-    randomExhibitionType,
-} from 'constants/fakeDatas';
+import { AuctionCardProps, ExhibitionCardProps } from '@const/card-type';
 
 interface Props {
-    ExhibitionsData: string[];
-    AuctionsData: string[];
+    ExhibitionsData: ExhibitionCardProps[];
+    AuctionsData: AuctionCardProps[];
 }
 
 const Home: NextPage<Props> = ({ ExhibitionsData, AuctionsData }: Props) => {
@@ -25,16 +21,14 @@ const Home: NextPage<Props> = ({ ExhibitionsData, AuctionsData }: Props) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-    const ExhibitionsData = (await getRandomExhibitions()).data.map(
-        (exhibition: randomExhibitionType) => JSON.stringify(exhibition),
-    );
-    // const AuctionData = JSON.stringify((await getRandomAuctions()).data);
-    const AuctionsData = fakeRandomAuctions.map((auction: randomAuctionType) =>
-        JSON.stringify(auction),
-    );
+    const ExhibitionsData = (await getRandomExhibitions()).data;
+    const AuctionsData = (await getRandomAuctions()).data;
 
     return {
-        props: { ExhibitionsData, AuctionsData } as Props,
+        props: {
+            ExhibitionsData: JSON.parse(JSON.stringify(ExhibitionsData)),
+            AuctionsData: JSON.parse(JSON.stringify(AuctionsData)),
+        } as Props,
     };
 };
 

--- a/client/utils/networking.ts
+++ b/client/utils/networking.ts
@@ -41,9 +41,7 @@ export const getExhibitions = (filter: string, page: number) => {
 };
 
 export const getRandomAuctions = () => {
-    return axios.get<ExhibitionCardProps[]>(
-        `${API_SERVER_URL}/art-works/random?status=onSale`,
-    );
+    return axios.get(`${API_SERVER_URL}/auctions/random?status=onSale`);
 };
 
 export const getAuctions = (filter: string, page: number) => {

--- a/server/src/auction/auction.repository.ts
+++ b/server/src/auction/auction.repository.ts
@@ -19,6 +19,7 @@ export class AuctionRepository extends Repository<Auction> {
     getRandomAuctions(): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')
+            .innerJoinAndSelect('auction.seller', 'seller')
             .orderBy('RAND()')
             .limit(3)
             .getMany();
@@ -27,6 +28,7 @@ export class AuctionRepository extends Repository<Auction> {
     findAllByAuctionOrderByNewest(page: number): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')
+            .innerJoinAndSelect('auction.seller', 'seller')
             .orderBy('auction.id', 'DESC')
             .offset(page * 15)
             .limit(15)
@@ -36,6 +38,7 @@ export class AuctionRepository extends Repository<Auction> {
     findAllByAuctionOrderByPopular(page: number): Promise<Auction[]> {
         return this.createQueryBuilder('auction')
             .innerJoinAndSelect('auction.artwork', 'artwork')
+            .innerJoinAndSelect('auction.seller', 'seller')
             .innerJoin(
                 subQuery =>
                     subQuery
@@ -58,6 +61,7 @@ export class AuctionRepository extends Repository<Auction> {
             .where(`auction.id = ${auctionId}`)
             .leftJoinAndSelect('auction.auctionHistories', 'history')
             .innerJoinAndSelect('auction.artwork', 'artwork')
+            .innerJoinAndSelect('auction.seller', 'seller')
             .getOne();
     }
 }

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -22,9 +22,13 @@ export class AuctionListItemDTO {
     @ApiProperty()
     type: string;
 
+    @ApiProperty()
+    artist: string;
+
     static from(auction: Auction): AuctionListItemDTO {
         const dto = new AuctionListItemDTO();
         const { title, description, croppedImage, price, type } = auction.artwork;
+        const { name } = auction.seller;
 
         dto.id = auction.id;
         dto.title = title;
@@ -32,6 +36,7 @@ export class AuctionListItemDTO {
         dto.thumbnailImage = croppedImage;
         dto.price = price;
         dto.type = type;
+        dto.artist = name;
 
         return dto;
     }

--- a/server/src/auction/dto/auctionDTOs.ts
+++ b/server/src/auction/dto/auctionDTOs.ts
@@ -8,12 +8,31 @@ export class AuctionListItemDTO {
     id: number;
 
     @ApiProperty()
-    artwork: Artwork;
+    title: string;
+
+    @ApiProperty()
+    description: string;
+
+    @ApiProperty()
+    thumbnailImage: string;
+
+    @ApiProperty()
+    price: string;
+
+    @ApiProperty()
+    type: string;
 
     static from(auction: Auction): AuctionListItemDTO {
         const dto = new AuctionListItemDTO();
+        const { title, description, croppedImage, price, type } = auction.artwork;
+
         dto.id = auction.id;
-        dto.artwork = auction.artwork;
+        dto.title = title;
+        dto.description = description;
+        dto.thumbnailImage = croppedImage;
+        dto.price = price;
+        dto.type = type;
+
         return dto;
     }
 }

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -7,9 +7,9 @@ import {
     ApiTags,
 } from '@nestjs/swagger';
 import {
-    getExhibitionApiResponse, getExhibitionsSortedByDeadlineApiOperation, getExhibitionsSortedByInterestApiOperation,
+    getExhibitionsSortedByDeadlineApiOperation,
+    getExhibitionsSortedByInterestApiOperation,
     getNewestExhibitionApiOperation,
-    getRandomExhibitionApiResponse,
     getRandomExhibitionsAPiOperation,
 } from '../swagger';
 
@@ -20,7 +20,7 @@ export class ExhibitionController {
 
     @Get('/random')
     @ApiOperation(getRandomExhibitionsAPiOperation)
-    @ApiResponse(getRandomExhibitionApiResponse)
+    @ApiResponse({ type: ExhibitionDTO })
     @ApiProperty({})
     getRandomExhibitions(): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getRandomExhibitions();
@@ -28,7 +28,7 @@ export class ExhibitionController {
 
     @Get('/newest')
     @ApiOperation(getNewestExhibitionApiOperation)
-    @ApiResponse(getExhibitionApiResponse)
+    @ApiResponse({ type: ExhibitionDTO })
     @ApiQuery({name: "page", type: Number })
     getNewestExhibitions(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getNewestExhibitions(page);
@@ -36,7 +36,7 @@ export class ExhibitionController {
 
     @Get('/deadline')
     @ApiOperation(getExhibitionsSortedByDeadlineApiOperation)
-    @ApiResponse(getExhibitionApiResponse)
+    @ApiResponse({ type: ExhibitionDTO })
     @ApiQuery({name: "page", type: Number })
     getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getExhibitionsSortedByDeadline(page);
@@ -44,7 +44,7 @@ export class ExhibitionController {
 
     @Get('/popular')
     @ApiOperation(getExhibitionsSortedByInterestApiOperation)
-    @ApiResponse(getExhibitionApiResponse)
+    @ApiResponse({ type: ExhibitionDTO })
     @ApiQuery({name: "page", type: Number })
     getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getExhibitionsSortedByInterest(page);

--- a/server/src/exhibition/controller/exhibition.controller.ts
+++ b/server/src/exhibition/controller/exhibition.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
 import { ExhibitionService } from '../service/exhibition.service';
-import { Exhibition } from '../exhibition.entity';
+import { ExhibitionDTO } from '../dto/exhibitionDTO';
 import {
     ApiOperation,
     ApiProperty, ApiQuery, ApiResponse,
@@ -13,7 +13,6 @@ import {
     getRandomExhibitionsAPiOperation,
 } from '../swagger';
 
-
 @Controller('/exhibitions')
 @ApiTags('전시회 컨트롤러')
 export class ExhibitionController {
@@ -23,7 +22,7 @@ export class ExhibitionController {
     @ApiOperation(getRandomExhibitionsAPiOperation)
     @ApiResponse(getRandomExhibitionApiResponse)
     @ApiProperty({})
-    getRandomExhibitions(): Promise<Exhibition[]> {
+    getRandomExhibitions(): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getRandomExhibitions();
     }
 
@@ -31,7 +30,7 @@ export class ExhibitionController {
     @ApiOperation(getNewestExhibitionApiOperation)
     @ApiResponse(getExhibitionApiResponse)
     @ApiQuery({name: "page", type: Number })
-    getNewestExhibitions(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+    getNewestExhibitions(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getNewestExhibitions(page);
     }
 
@@ -39,7 +38,7 @@ export class ExhibitionController {
     @ApiOperation(getExhibitionsSortedByDeadlineApiOperation)
     @ApiResponse(getExhibitionApiResponse)
     @ApiQuery({name: "page", type: Number })
-    getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+    getExhibitionsSortedByDeadline(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getExhibitionsSortedByDeadline(page);
     }
 
@@ -47,7 +46,7 @@ export class ExhibitionController {
     @ApiOperation(getExhibitionsSortedByInterestApiOperation)
     @ApiResponse(getExhibitionApiResponse)
     @ApiQuery({name: "page", type: Number })
-    getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<Exhibition[]> {
+    getExhibitionsSortedByInterest(@Query('page', ParseIntPipe) page: number): Promise<ExhibitionDTO[]> {
         return this.exhibitionService.getExhibitionsSortedByInterest(page);
     }
 

--- a/server/src/exhibition/dto/exhibitionDTO.ts
+++ b/server/src/exhibition/dto/exhibitionDTO.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exhibition } from '../exhibition.entity';
+
+export class ExhibitionDTO {
+    @ApiProperty()
+    id: number;
+
+    @ApiProperty()
+    title: string;
+
+    @ApiProperty()
+    description: string;
+
+    @ApiProperty()
+    artist: string;
+
+    @ApiProperty()
+    collaborator: string;
+
+    @ApiProperty()
+    thumbnailImage: string;
+
+    @ApiProperty()
+    category: string;
+
+    static from(exhibition: Exhibition): ExhibitionDTO {
+        const dto = new ExhibitionDTO();
+        const { title, description, artist, collaborator, thumbnailImage, categories } = exhibition;
+
+        dto.title = title;
+        dto.description = description;
+        dto.artist = artist.name;
+        dto.collaborator = collaborator;
+        dto.thumbnailImage = thumbnailImage;
+        dto.category = categories?.join(',');
+
+        return dto;
+    }
+}

--- a/server/src/exhibition/exhibition.repository.ts
+++ b/server/src/exhibition/exhibition.repository.ts
@@ -16,6 +16,7 @@ export class ExhibitionRepository extends Repository<Exhibition> {
 
     async getNewestExhibitions(page: number): Promise<Exhibition[]> {
         return await this.createQueryBuilder('exhibition')
+            .innerJoinAndSelect('exhibition.artist', 'artist')
             .where('exhibition.start_at <= now()')
             .orderBy(`now() - exhibition.start_at`, 'ASC')
             .offset(page * 15)
@@ -25,6 +26,7 @@ export class ExhibitionRepository extends Repository<Exhibition> {
 
     async getExhibitionsSortedByDeadline(page: number): Promise<Exhibition[]> {
         return await this.createQueryBuilder('exhibition')
+            .innerJoinAndSelect('exhibition.artist', 'artist')
             .orderBy('exhibition.end_at - now()', 'ASC')
             .offset(page * 15)
             .limit(15)
@@ -33,18 +35,20 @@ export class ExhibitionRepository extends Repository<Exhibition> {
 
     async getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
         return await this.createQueryBuilder('exhibition')
+            .innerJoinAndSelect('exhibition.artist', 'artist')
             .innerJoin(subQuery => {
                 return subQuery
-                    .select('artwork.exhibition_id')
+                    .select('artwork.exhibition_id, count(interest_artwork.artwork_id) as count')
                     .from(Artwork, 'artwork')
-                    .innerJoin(
+                    .leftJoin(
                         InterestArtwork,
                         'interest_artwork',
                         'artwork.id = interest_artwork.artwork_id'
                     )
+                    .groupBy('artwork.id')
             }, 'artwork', 'artwork.exhibition_id = exhibition.id')
-            .groupBy('exhibition.id')
-            .orderBy('count(exhibition.id)', 'DESC')
+            .orderBy('artwork.count', 'DESC')
+            .addOrderBy('exhibition.id', 'DESC')
             .offset(page * 15)
             .limit(15)
             .getMany();

--- a/server/src/exhibition/service/exhibition.service.ts
+++ b/server/src/exhibition/service/exhibition.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ExhibitionRepository } from '../exhibition.repository';
-import { Exhibition } from "../exhibition.entity";
+import { ExhibitionDTO } from '../dto/exhibitionDTO';
 
 @Injectable()
 export class ExhibitionService {
@@ -10,20 +10,24 @@ export class ExhibitionService {
         private exhibitionRepository: ExhibitionRepository
     ) {}
 
-    getRandomExhibitions(): Promise<Exhibition[]> {
-        return this.exhibitionRepository.getRandomExhibitions();
+    async getRandomExhibitions(): Promise<ExhibitionDTO[]> {
+        const exhibitions = await this.exhibitionRepository.getRandomExhibitions();
+        return exhibitions.map(exhibition => ExhibitionDTO.from(exhibition));
     }
 
-    getNewestExhibitions(page: number): Promise<Exhibition[]> {
-        return this.exhibitionRepository.getNewestExhibitions(page);
+    async getNewestExhibitions(page: number): Promise<ExhibitionDTO[]> {
+        const exhibitions = await this.exhibitionRepository.getNewestExhibitions(page);
+        return exhibitions.map(exhibition => ExhibitionDTO.from(exhibition));
     }
 
-    getExhibitionsSortedByDeadline(page: number): Promise<Exhibition[]> {
-        return this.exhibitionRepository.getExhibitionsSortedByDeadline(page);
+    async getExhibitionsSortedByDeadline(page: number): Promise<ExhibitionDTO[]> {
+        const exhibitions = await this.exhibitionRepository.getExhibitionsSortedByDeadline(page);
+        return exhibitions.map(exhibition => ExhibitionDTO.from(exhibition));
     }
 
-    getExhibitionsSortedByInterest(page: number): Promise<Exhibition[]> {
-        return this.exhibitionRepository.getExhibitionsSortedByInterest(page);
+    async getExhibitionsSortedByInterest(page: number): Promise<ExhibitionDTO[]> {
+        const exhibitions = await this.exhibitionRepository.getExhibitionsSortedByInterest(page);
+        return exhibitions.map(exhibition => ExhibitionDTO.from(exhibition));
     }
 
 }

--- a/server/src/exhibition/swagger/index.ts
+++ b/server/src/exhibition/swagger/index.ts
@@ -5,21 +5,9 @@ export const getRandomExhibitionsAPiOperation = {
     description: '랜덤으로 전시회 5개를 조회한다.',
 }
 
-export const getRandomExhibitionApiResponse = {
-    description: '전시회 객체 5개 배열',
-    type: Exhibition,
-    isArray: true,
-}
-
 export const getNewestExhibitionApiOperation = {
     summary: '최신순 전시회 15개 조회 API',
     description: '최신순으로 전시회 15개를 조회한다.'
-}
-
-export const getExhibitionApiResponse = {
-    description: '전시회 객체 15개 배열',
-    type: Exhibition,
-    isArray: true,
 }
 
 export const getExhibitionsSortedByDeadlineApiOperation = {


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 경매 작품의 cropped_image 변수명을 thumbnail로 통일
- 경매 작품 반환 DTO 개선
  - artwork로 감싸져 있는 부분 개선
- 메인 페이지 랜덤 전시회, 랜덤 옥션 API 연동 및 fakedata 제거

### 📑 구현한 내용 목록
- [x] 경매 작품의 cropped_image 변수명을 thumbnail로 통일
- [x] 경매 작품 반환 DTO 개선
- [x] 메인 페이지 랜덤 전시회, 랜덤 옥션 API 연동 

### 🚧 주의 사항
- 경매 작품이랑 전시회 보여주는 카드에서 아티스트가 필요하여 user 테이블 조인이 추가되었습니다. 
- API를 모두 작성한 후 개선해보도록 하겠습니다.

### 🖥 스크린 샷
![image](https://user-images.githubusercontent.com/76088639/141061295-a3af0e96-9976-4f7a-8bc1-f18ade9a49b0.png)

close #145 
