### PR TITLE
feat: element 선택 , 주변 선 ,주변 점 - #134

### DIFF
--- a/client/components/Exhibition/Editor/EditorElement.tsx
+++ b/client/components/Exhibition/Editor/EditorElement.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { EditorElementStyle, EditorElementType } from '.';
-import { onDraggable } from './utils';
+import { onDraggable, getPositions, getLineStyle } from './utils';
 
 interface Prop {
     style: EditorElementStyle;
@@ -29,6 +29,9 @@ const EditorElement = ({
     const positionRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
     const [currentStyle, setCurrentStyle] = useState(style);
     let isSelected = currentElements.includes(idx);
+    const element = elementRef?.current;
+    const [LT, LB, RT, RB] = getPositions(element);
+
     const calculateStyle = () => {
         return {
             transform: `translate(${positionRef.current.x}px, ${positionRef.current.y}px)`,
@@ -37,6 +40,31 @@ const EditorElement = ({
             backgroundColor: currentStyle.backgroundColor,
         };
     };
+
+    const getBorderController = () => {
+        return (
+            <>
+                {getSpots()}
+                {getLines()}
+            </>
+        );
+    };
+
+    const getSpots = () => {
+        return <div></div>;
+    };
+
+    const getLines = () => {
+        return (
+            <>
+                <div className="lines" style={getLineStyle(LT, LB, LT)}></div>
+                <div className="lines" style={getLineStyle(LT, RT, LT)}></div>
+                <div className="lines" style={getLineStyle(LB, RB, LT)}></div>
+                <div className="lines" style={getLineStyle(RT, RB, LT)}></div>
+            </>
+        );
+    };
+
     useEffect(() => {
         isSelected = currentElements.includes(idx);
     }, [currentElements]);
@@ -45,9 +73,11 @@ const EditorElement = ({
         <div
             onClick={() => keyToCurrentElements([idx])}
             style={calculateStyle()}
-            onMouseDown={(e) => isSelected && onDraggable(e, elementRef)}
+            onMouseDown={(e) => isSelected && onDraggable(e, element)}
             ref={elementRef}
-        ></div>
+        >
+            {isSelected && getBorderController()}
+        </div>
     );
 };
 

--- a/client/components/Exhibition/Editor/EditorElement.tsx
+++ b/client/components/Exhibition/Editor/EditorElement.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { EditorElementStyle, EditorElementType } from '.';
-import { onDraggable, getPositions, getLineStyle } from './utils';
+import { onDraggable, getPositions, getLineStyle, getDotStyle } from './utils';
 
 interface Prop {
     style: EditorElementStyle;
@@ -44,23 +44,46 @@ const EditorElement = ({
     const getBorderController = () => {
         return (
             <>
-                {getSpots()}
                 {getLines()}
+                {getSpots()}
             </>
         );
     };
 
     const getSpots = () => {
-        return <div></div>;
+        return (
+            <>
+                <div className="dot LW" style={getDotStyle(LT, LT)}></div>
+                <div className="dot N" style={getDotStyle(LT, LT, RT)}></div>
+                <div className="dot NE" style={getDotStyle(LT, RT)}></div>
+                <div className="dot E" style={getDotStyle(LT, RT, RB)}></div>
+                <div className="dot SE" style={getDotStyle(LT, RB)}></div>
+                <div className="dot S" style={getDotStyle(LT, LB, RB)}></div>
+                <div className="dot SW" style={getDotStyle(LT, LB)}></div>
+                <div className="dot W" style={getDotStyle(LT, LB, LT)}></div>
+            </>
+        );
     };
 
     const getLines = () => {
         return (
             <>
-                <div className="lines" style={getLineStyle(LT, LB, LT)}></div>
-                <div className="lines" style={getLineStyle(LT, RT, LT)}></div>
-                <div className="lines" style={getLineStyle(LB, RB, LT)}></div>
-                <div className="lines" style={getLineStyle(RT, RB, LT)}></div>
+                <div
+                    className="lines"
+                    style={getLineStyle(LT, LB, LT, RB)}
+                ></div>
+                <div
+                    className="lines"
+                    style={getLineStyle(LT, RT, LT, RB)}
+                ></div>
+                <div
+                    className="lines"
+                    style={getLineStyle(LB, RB, LT, RB)}
+                ></div>
+                <div
+                    className="lines"
+                    style={getLineStyle(RT, RB, LT, RB)}
+                ></div>
             </>
         );
     };

--- a/client/components/Exhibition/Editor/EditorElement.tsx
+++ b/client/components/Exhibition/Editor/EditorElement.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { EditorElementStyle, EditorElementType } from '.';
+import { onDraggable } from './utils';
 
 interface Prop {
     style: EditorElementStyle;
@@ -8,6 +9,9 @@ interface Prop {
     imgSrc?: string;
     text?: string;
     align?: string;
+    idx: number;
+    currentElements: number[];
+    keyToCurrentElements: (arr: number[]) => void;
 }
 
 const EditorElement = ({
@@ -17,34 +21,14 @@ const EditorElement = ({
     imgSrc,
     text,
     align,
+    idx,
+    currentElements = [],
+    keyToCurrentElements,
 }: Prop) => {
     const elementRef = useRef<HTMLDivElement>(null);
     const positionRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
     const [currentStyle, setCurrentStyle] = useState(style);
-
-    const moveElement = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-        const element = elementRef.current;
-        const dom = element?.getBoundingClientRect();
-        if (!dom || !element) return;
-
-        let shiftX = e.clientX - dom.left;
-        let shiftY = e.clientY - dom.top + element.offsetHeight / 2;
-
-        element.style.setProperty('position', 'absolute');
-
-        const onMouseMove = (e: any) => {
-            element.style.setProperty('left', `${e.pageX - shiftX}px`);
-            element.style.setProperty('top', `${e.pageY - shiftY}px`);
-        };
-
-        document.addEventListener('mousemove', onMouseMove);
-
-        const removeEvent = () => {
-            document.removeEventListener('mousemove', onMouseMove);
-            element.onmouseup = null;
-        };
-        document.body.onmouseup = removeEvent;
-    };
+    let isSelected = currentElements.includes(idx);
     const calculateStyle = () => {
         return {
             transform: `translate(${positionRef.current.x}px, ${positionRef.current.y}px)`,
@@ -53,11 +37,15 @@ const EditorElement = ({
             backgroundColor: currentStyle.backgroundColor,
         };
     };
+    useEffect(() => {
+        isSelected = currentElements.includes(idx);
+    }, [currentElements]);
 
     return (
         <div
+            onClick={() => keyToCurrentElements([idx])}
             style={calculateStyle()}
-            onMouseDown={(e) => moveElement(e)}
+            onMouseDown={(e) => isSelected && onDraggable(e, elementRef)}
             ref={elementRef}
         ></div>
     );

--- a/client/components/Exhibition/Editor/index.tsx
+++ b/client/components/Exhibition/Editor/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
-import { addClass } from './utils';
+import React, { useState, useRef } from 'react';
 import EditorElement from './EditorElement';
 
 enum EditorElementName {
@@ -10,7 +9,8 @@ enum EditorElementName {
 }
 export type EditorElementType = 'RECTANGULAR' | 'TEXT' | 'IMAGE';
 export type EditorElementStyle = {
-    translate: { x: number; y: number };
+    top: number;
+    left: number;
     backgroundColor: string;
     size: { width: number; height: number };
 };
@@ -22,7 +22,7 @@ export interface EditorElementProp {
 
 const Editor = () => {
     const [elements, setElements] = useState<EditorElementProp[]>([]);
-    const addRectangular = () => {};
+    const [currentElements, setCurrentElements] = useState<number[]>([]);
 
     const createRectangular = () => {
         const element: EditorElementProp = {
@@ -32,22 +32,28 @@ const Editor = () => {
                     width: 100,
                     height: 100,
                 },
-                translate: {
-                    x: 0,
-                    y: 0,
-                },
+                top: 0,
+                left: 0,
                 backgroundColor: 'black',
             },
         };
         setElements([...elements, element]);
     };
 
+    const keyToCurrentElements = (keyyArr: number[]) => {
+        setCurrentElements(keyyArr);
+    };
+
     const renderElements = () => {
+        console.log('renderelements');
         return elements.map((element, idx) => (
             <EditorElement
                 key={idx}
+                idx={idx}
                 style={element.style}
                 type={EditorElementName.rectangular}
+                currentElements={currentElements}
+                keyToCurrentElements={keyToCurrentElements}
             ></EditorElement>
         ));
     };

--- a/client/components/Exhibition/Editor/index.tsx
+++ b/client/components/Exhibition/Editor/index.tsx
@@ -45,7 +45,6 @@ const Editor = () => {
     };
 
     const renderElements = () => {
-        console.log('renderelements');
         return elements.map((element, idx) => (
             <EditorElement
                 key={idx}

--- a/client/components/Exhibition/Editor/utils.ts
+++ b/client/components/Exhibition/Editor/utils.ts
@@ -1,3 +1,28 @@
 import EditorElement from './EditorElement';
 
-export const addClass = () => {};
+export const onDraggable = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    elementRef: React.RefObject<HTMLDivElement>,
+) => {
+    const element = elementRef.current;
+    const dom = element?.getBoundingClientRect();
+    if (!dom || !element) return;
+
+    let shiftX = e.clientX - dom.left;
+    let shiftY = e.clientY - dom.top + element.offsetHeight / 2;
+
+    element.style.setProperty('position', 'absolute');
+
+    const onMouseMove = (e: any) => {
+        element.style.setProperty('left', `${e.pageX - shiftX}px`);
+        element.style.setProperty('top', `${e.pageY - shiftY}px`);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+
+    const removeEvent = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        element.onmouseup = null;
+    };
+    document.body.onmouseup = removeEvent;
+};

--- a/client/components/Exhibition/Editor/utils.ts
+++ b/client/components/Exhibition/Editor/utils.ts
@@ -45,18 +45,21 @@ export const getPositions = (element: HTMLDivElement | null) => {
 export const getLineStyle = (
     p1: number[],
     p2: number[],
-    originPoint: number[],
+    originStartPoint: number[],
+    originEndPoint: number[],
 ) => {
-    console.log(p1, p2, originPoint);
+    console.log(p1, p2, originEndPoint);
     const distX = p2[0] - p1[0];
     const distY = p2[1] - p1[1];
+    const width = originEndPoint[0] - originStartPoint[0];
+    const height = originEndPoint[1] - originStartPoint[1];
     const degree = distX ? 90 : 0;
     let trans1, trans2;
     if (degree) {
-        trans1 = 50;
-        trans2 = p1[1] > originPoint[1] ? 50 : -50;
+        trans1 = width / 2;
+        trans2 = p1[1] > originStartPoint[1] ? height / 2 : (height / 2) * -1;
     } else {
-        trans1 = p1[0] > originPoint[0] ? 100 : 0;
+        trans1 = p1[0] > originStartPoint[0] ? width : 0;
         trans2 = 0;
     }
     return {

--- a/client/components/Exhibition/Editor/utils.ts
+++ b/client/components/Exhibition/Editor/utils.ts
@@ -2,9 +2,8 @@ import EditorElement from './EditorElement';
 
 export const onDraggable = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    elementRef: React.RefObject<HTMLDivElement>,
+    element: HTMLDivElement | null,
 ) => {
-    const element = elementRef.current;
     const dom = element?.getBoundingClientRect();
     if (!dom || !element) return;
 
@@ -13,9 +12,9 @@ export const onDraggable = (
 
     element.style.setProperty('position', 'absolute');
 
-    const onMouseMove = (e: any) => {
-        element.style.setProperty('left', `${e.pageX - shiftX}px`);
-        element.style.setProperty('top', `${e.pageY - shiftY}px`);
+    const onMouseMove = (ev: MouseEvent) => {
+        element.style.setProperty('left', `${ev.pageX - shiftX}px`);
+        element.style.setProperty('top', `${ev.pageY - shiftY}px`);
     };
 
     document.addEventListener('mousemove', onMouseMove);
@@ -25,4 +24,47 @@ export const onDraggable = (
         element.onmouseup = null;
     };
     document.body.onmouseup = removeEvent;
+};
+
+export const getPositions = (element: HTMLDivElement | null) => {
+    if (!element)
+        return [
+            [0, 0],
+            [0, 0],
+            [0, 0],
+            [0, 0],
+        ];
+    const { left, top, right, bottom } = element.getBoundingClientRect();
+    return [
+        [left, top],
+        [left, bottom],
+        [right, top],
+        [right, bottom],
+    ];
+};
+export const getLineStyle = (
+    p1: number[],
+    p2: number[],
+    originPoint: number[],
+) => {
+    console.log(p1, p2, originPoint);
+    const distX = p2[0] - p1[0];
+    const distY = p2[1] - p1[1];
+    const degree = distX ? 90 : 0;
+    let trans1, trans2;
+    if (degree) {
+        trans1 = 50;
+        trans2 = p1[1] > originPoint[1] ? 50 : -50;
+    } else {
+        trans1 = p1[0] > originPoint[0] ? 100 : 0;
+        trans2 = 0;
+    }
+    return {
+        position: 'absolute' as 'absolute',
+        transform: `translate(${trans1}px,${trans2}px) rotate(${degree}deg)`,
+        height: '100px',
+        width: '1px',
+        content: '',
+        backgroundColor: '#3A8FD6',
+    };
 };

--- a/client/components/Exhibition/Editor/utils.ts
+++ b/client/components/Exhibition/Editor/utils.ts
@@ -48,7 +48,6 @@ export const getLineStyle = (
     originStartPoint: number[],
     originEndPoint: number[],
 ) => {
-    console.log(p1, p2, originEndPoint);
     const distX = p2[0] - p1[0];
     const distY = p2[1] - p1[1];
     const width = originEndPoint[0] - originStartPoint[0];
@@ -69,5 +68,25 @@ export const getLineStyle = (
         width: '1px',
         content: '',
         backgroundColor: '#3A8FD6',
+    };
+};
+
+export const getDotStyle = (
+    originPoint: number[],
+    p1: number[],
+    p2?: number[],
+) => {
+    const [X, Y] = p2 ? [~~((p1[0] + p2[0]) / 2), ~~((p1[1] + p2[1]) / 2)] : p1;
+    const [Left, Top] = [X - originPoint[0] - 5, Y - originPoint[1] - 5];
+    return {
+        position: 'absolute' as 'absolute',
+        top: Top,
+        left: Left,
+        backgroundColor: '#3A8FD6',
+        borderRadius: '10px',
+        border: '2px solid #eee',
+        width: '10px',
+        height: '10px',
+        cursor: 'crosshair',
     };
 };

--- a/client/constants/card-type.ts
+++ b/client/constants/card-type.ts
@@ -1,3 +1,5 @@
+import { AUCTION_STATE } from './auction-state';
+
 export interface ExhibitionCardProps {
     title: string;
     description?: string;
@@ -17,7 +19,7 @@ export interface AuctionCardProps {
     price?: number;
     id: number;
     exhibitionId?: null | number;
-    status: string;
+    status: AUCTION_STATE;
     type: string;
 }
 export const CardSize = {

--- a/client/pages/exhibition/editor.tsx
+++ b/client/pages/exhibition/editor.tsx
@@ -1,0 +1,12 @@
+import Editor from '@components/Exhibition/Editor';
+import React from 'react';
+
+const editor = () => {
+    return (
+        <div>
+            <Editor></Editor>
+        </div>
+    );
+};
+
+export default editor;


### PR DESCRIPTION
### 🔨 작업 내용 설명

element를 선택할 시에만 움직이게 한다
선택했을때는 선과 점을 찍어준다.

### 📑 구현한 내용 목록

- [x] element 선택
- [x] element 주변 선
- [x] element 주변 점

### 🚧 주의 사항


### 🖥 스크린 샷

결과화면 스크린샷
![image](https://user-images.githubusercontent.com/13018853/141118461-b13149ae-cffd-429a-8120-da13e3d22982.png)

