### PR TITLE
feat: nftToken 저장 API 및 전시회 테이블 size 필드 추가

### DIFF
--- a/client/interfaces.ts
+++ b/client/interfaces.ts
@@ -3,6 +3,7 @@ export interface Artwork {
     croppedImage: string;
     originalImage: string;
     exhibitionId: number;
+    cid: string;
     nftToken: string;
     description?: string;
     price: number;

--- a/client/pages/artwork/result/index.tsx
+++ b/client/pages/artwork/result/index.tsx
@@ -33,7 +33,7 @@ const ResultPage = () => {
         });
 
         const result = await contract.methods
-            .createNFT(account, artwork!.nftToken)
+            .createNFT(account, artwork!.cid)
             .send({ from: account, gas: GAS_LIMIT });
         const tokenId = result.events.Transfer.returnValues.tokenId;
 

--- a/server/src/artwork/artwork.entity.ts
+++ b/server/src/artwork/artwork.entity.ts
@@ -30,6 +30,9 @@ export class Artwork {
     status: string;
 
     @Column()
+    cid: string;
+
+    @Column({ nullable: true })
     nftToken: string;
 
     @Column({ type: 'text' })

--- a/server/src/artwork/artwork.repository.ts
+++ b/server/src/artwork/artwork.repository.ts
@@ -1,5 +1,5 @@
 import { ObjectStorageData } from 'src/image/dto/ImageDTOs';
-import { EntityRepository, In, Repository } from 'typeorm';
+import { EntityRepository, In, Repository, UpdateResult } from 'typeorm';
 import { Artwork } from './artwork.entity';
 import { ArtworkStatus } from './artwork.status.enum';
 import { CreateArtworkDTO } from './dto/artworkDTOs';
@@ -92,4 +92,9 @@ export class ArtworkRepository extends Repository<Artwork> {
             .where({ id: In(artworkIds) })
             .execute();
     }
+
+    async updateNFTToken(id: number, nftToken: string): Promise<UpdateResult> {
+        return await this.update(id, { nftToken });
+    }
+
 }

--- a/server/src/artwork/artwork.repository.ts
+++ b/server/src/artwork/artwork.repository.ts
@@ -12,7 +12,7 @@ export class ArtworkRepository extends Repository<Artwork> {
         createArtWorkDTO: CreateArtworkDTO,
         { Location: originalImagePath }: ObjectStorageData,
         { Location: croppedImagePath }: ObjectStorageData,
-        nftToken: string,
+        cid: string,
     ): Artwork {
         return this.create({
             title: createArtWorkDTO.title,
@@ -20,7 +20,7 @@ export class ArtworkRepository extends Repository<Artwork> {
             description: createArtWorkDTO.description,
             originalImage: originalImagePath,
             croppedImage: croppedImagePath,
-            nftToken: nftToken,
+            cid,
         });
     }
 

--- a/server/src/artwork/controller/artwork.controller.ts
+++ b/server/src/artwork/controller/artwork.controller.ts
@@ -4,7 +4,7 @@ import {
     Get,
     HttpCode,
     Param,
-    ParseIntPipe,
+    ParseIntPipe, Patch,
     Post,
     Req,
     UploadedFile,
@@ -24,10 +24,12 @@ import {
     createArtworkApiBody,
     interestApiOperation,
     getArtworkApiOperation,
+    updateNFTTokenApiOperation,
 } from '../swagger';
 import { InterestArtwork } from 'src/interestArtwork/interestArtwork.entity';
 import { InterestArtworkService } from 'src/interestArtwork/interestArtwork.service';
 import { Artwork } from '../artwork.entity';
+import { UpdateResult } from 'typeorm';
 
 @Controller('artworks')
 @ApiTags('작품 컨트롤러')
@@ -72,5 +74,18 @@ export class ArtworkController {
         @Req() { user }: Express.Request & { user: User },
     ): Promise<boolean> {
         return this.interestArtworkService.insertInterestArtwork(user, interestRequestDTO);
+    }
+
+    @Patch('/:artworkId/nft')
+    @UseGuards(CustomAuthGuard)
+    @ApiOperation(updateNFTTokenApiOperation)
+    @ApiParam({ name: 'artworkId', type: Number })
+    @ApiBody({ type: String })
+    @ApiResponse({ type: UpdateResult })
+    updateNFTToken(
+        @Param('artworkId', ParseIntPipe) artworkId: number,
+        @Body('nftToken') nftToken: string
+    ): Promise<UpdateResult> {
+        return this.artworkService.updateNFTToken(artworkId, nftToken);
     }
 }

--- a/server/src/artwork/dto/artworkDTOs.ts
+++ b/server/src/artwork/dto/artworkDTOs.ts
@@ -21,12 +21,12 @@ export class NewArtworkDTO {
     id: number;
 
     @ApiProperty()
-    nftToken: string;
+    cid: string;
 
     static from(artwork: Artwork): NewArtworkDTO {
         const newArtworkDTO = new NewArtworkDTO();
         newArtworkDTO.id = artwork.id;
-        newArtworkDTO.nftToken = artwork.nftToken;
+        newArtworkDTO.cid = artwork.cid;
         return newArtworkDTO;
     }
 }

--- a/server/src/artwork/service/artwork.service.ts
+++ b/server/src/artwork/service/artwork.service.ts
@@ -8,6 +8,7 @@ import { AuctionRepository } from 'src/auction/auction.repository';
 import { User } from 'src/user/user.entity';
 import { ArtworkStatus } from '../artwork.status.enum';
 import { Artwork } from '../artwork.entity';
+import { UpdateResult } from 'typeorm';
 
 @Injectable()
 export class ArtworkService {
@@ -70,4 +71,9 @@ export class ArtworkService {
     async bulkUpdateArtworkState(artworkIds: number[]): Promise<void> {
         this.artworkRepository.bulkUpdateArtworkState(artworkIds);
     }
+
+    updateNFTToken(artworkId: number, nftToken: string): Promise<UpdateResult> {
+        return this.artworkRepository.updateNFTToken(artworkId, nftToken);
+    }
+
 }

--- a/server/src/artwork/service/artwork.service.ts
+++ b/server/src/artwork/service/artwork.service.ts
@@ -24,7 +24,7 @@ export class ArtworkService {
         this.ipfs = create({ url: process.env.IPFS_URL });
     }
 
-    async createNFTToken(image): Promise<string> {
+    async createCID(image): Promise<string> {
         const { cid } = await this.ipfs.add(image.buffer);
         return cid.toString();
     }
@@ -42,7 +42,7 @@ export class ArtworkService {
                     ...image,
                     buffer: croppedImageBuffer,
                 }),
-                this.createNFTToken(image),
+                this.createCID(image),
             ]);
 
             const newArtwork = this.artworkRepository.createArtwork(createArtworkDTO, originalImage, croppedImage, cid);

--- a/server/src/artwork/swagger/index.ts
+++ b/server/src/artwork/swagger/index.ts
@@ -31,4 +31,7 @@ export const getArtworkApiOperation = {
     description: '작품 ID로 특정 작품을 조회한다.'
 };
 
-
+export const updateNFTTokenApiOperation = {
+    summary: '작품의 NFT TOKEN 수정 API',
+    description: '등록한 작품의 NFT 토큰을 발급 받고 저장한다.'
+};

--- a/server/src/exhibition/dto/exhibitionDTO.ts
+++ b/server/src/exhibition/dto/exhibitionDTO.ts
@@ -74,15 +74,15 @@ export class HoldExhibitionDTO {
     @IsNotEmpty()
     contents: string;
 
-    thumbnail: string;
-
     categories: string;
 
     artworkIds: number[];
 
+    size: string;
+
     static from(exhibition: Exhibition): HoldExhibitionDTO {
         const dto = new HoldExhibitionDTO();
-        const { id, title, collaborator, theme, description, startAt, endAt, contents, categories } = exhibition;
+        const { id, title, collaborator, theme, description, startAt, endAt, contents, categories, size } = exhibition;
 
         dto.id = id;
         dto.title = title;
@@ -93,6 +93,7 @@ export class HoldExhibitionDTO {
         dto.endAt = endAt;
         dto.contents = contents;
         dto.categories = categories;
+        dto.size = `${size}`;
         return dto;
     }
 

--- a/server/src/exhibition/exhibition.entity.ts
+++ b/server/src/exhibition/exhibition.entity.ts
@@ -36,6 +36,9 @@ export class Exhibition {
     })
     contents: string;
 
+    @Column()
+    size: number;
+
     @ManyToOne(type => User, user => user.exhibitionList)
     artist: User;
 

--- a/server/src/exhibition/exhibition.repository.ts
+++ b/server/src/exhibition/exhibition.repository.ts
@@ -65,17 +65,20 @@ export class ExhibitionRepository extends Repository<Exhibition> {
     }
 
     createExhibition(thumbnailPath: string, holdExhibitionDTO: HoldExhibitionDTO, user: User): Exhibition {
+        const { title, collaborator, description, startAt, endAt, contents, theme, categories, size } = holdExhibitionDTO;
+
         return this.create({
-            title: holdExhibitionDTO.title,
-            collaborator: holdExhibitionDTO.collaborator,
-            description: holdExhibitionDTO.description,
-            startAt: holdExhibitionDTO.startAt,
-            endAt: holdExhibitionDTO.endAt,
+            title,
+            collaborator,
+            description,
+            startAt,
+            endAt,
             thumbnailImage: thumbnailPath,
-            contents: holdExhibitionDTO.contents,
-            theme: holdExhibitionDTO.theme,
+            contents,
+            theme,
             artist: user,
-            categories: JSON.stringify(holdExhibitionDTO.categories),
+            categories: JSON.stringify(categories),
+            size: Number(size),
         });
     }
 }

--- a/server/src/exhibition/swagger/index.ts
+++ b/server/src/exhibition/swagger/index.ts
@@ -35,6 +35,7 @@ export const holdExhibitionApiBody = {
             artworkIds: { type: 'number[]', nullable: true },
             categoryIds: { type: 'number[]', nullable: true },
             contents: { type: 'string', nullable: false },
+            size: { type: 'string', nullable: true },
         },
     },
 };


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 아트워크 nftToken 저장 API 구현
- 전시회 테이블 size 필드 추가 및 DTO 수정

### 📑 구현한 내용 목록
- [x] 아트워크 nftToken 저장 API 구현
- [x] 전시회 테이블 size 필드 추가 및 DTO 수정

### 🚧 주의 사항

### 🖥 스크린 샷

close #196 
