### PR TITLE
fix:  현재 거래중인 작품 조회 api 쿼리 수정

### DIFF
--- a/server/src/auctionHistory/auctionHistory.repository.ts
+++ b/server/src/auctionHistory/auctionHistory.repository.ts
@@ -3,21 +3,10 @@ import { AuctionHistory } from './auctionHistory.entity';
 
 @EntityRepository(AuctionHistory)
 export class AuctionHistoryRepository extends Repository<AuctionHistory> {
-
     async getHighestAuctionHistory(auctionId: number): Promise<AuctionHistory> {
         return await this.createQueryBuilder('auctionHistory')
             .where('auctionHistory.auction_id = :auctionId', { auctionId })
             .orderBy('auctionHistory.id', 'DESC')
             .getOne();
     }
-
-    async getBiddingAuctions(bidderId: number): Promise<AuctionHistory[]> {
-        return await this.createQueryBuilder('auctionHistory')
-            .where('auctionHistory.bidderId = :bidderId', { bidderId })
-            .innerJoinAndSelect('auctionHistory.auction', 'auction')
-            .innerJoinAndSelect('auction.artwork', 'artwork')
-            .groupBy('artwork.id')
-            .getMany();
-    }
-
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -9,7 +9,6 @@ import { UpdateResult } from 'typeorm';
 import { RequestUserDTO } from '../dto/userDTO';
 import { ExhibitionRepository } from '../../exhibition/exhibition.repository';
 import { Exhibition } from '../../exhibition/exhibition.entity';
-import { AuctionHistoryRepository } from '../../auctionHistory/auctionHistory.repository';
 
 @Injectable()
 export class UserService {
@@ -21,8 +20,6 @@ export class UserService {
         private artworkRepository: ArtworkRepository,
         @InjectRepository(ExhibitionRepository)
         private exhibitionRepository: ExhibitionRepository,
-        @InjectRepository(AuctionHistoryRepository)
-        private auctionHistoryRepository: AuctionHistoryRepository
     ) {}
 
     async checkRegisteredUser(userId: string, name: string, avatar: string, loginStrategy: string): Promise<User> {
@@ -48,11 +45,8 @@ export class UserService {
         file: Express.Multer.File,
         requestUserDTO: RequestUserDTO,
     ): Promise<UpdateResult> {
-        if(!file) {
-            return this.userRepository.update(
-                { id },
-                { ...requestUserDTO }
-            );
+        if (!file) {
+            return this.userRepository.update({ id }, { ...requestUserDTO });
         }
         const image = await this.imageService.fileUpload(file);
         const avatar = image.Location;
@@ -68,9 +62,8 @@ export class UserService {
         return this.artworkRepository.getInterestArtworks(id);
     }
 
-    async getBiddingArtworks({ id }: User): Promise<Artwork[]> {
-        const auctionHistories = await this.auctionHistoryRepository.getBiddingAuctions(id);
-        return auctionHistories.map(el => el.auction.artwork);
+    getBiddingArtworks({ id }: User): Promise<Artwork[]> {
+        return this.artworkRepository.findAllByBidding(id);
     }
 
     getBiddedArtworks(nftTokens: string): Promise<Artwork[]> {


### PR DESCRIPTION
### 🔨 작업 내용 설명

group by로 조회하는 sql의 조회 필드들이 집계함수가 아닌 필드들
이었습니다. 그래서 group by 제거하고 서브쿼리로 해결했습니다.

### 🚧 주의 사항

group by의 조회 필드는 집계함수에 의한 값이거나 group by한 필드들만 select 가능합니다.

- close #220