### PR TITLE
fix: 이미지 z-index 수정시에 선택이 안되던 오류 해결

### DIFF
--- a/client/components/Exhibition/EditorPage/Editor/index.tsx
+++ b/client/components/Exhibition/EditorPage/Editor/index.tsx
@@ -124,8 +124,8 @@ const Editor = ({ elements, setElements }: Props, editorRef: any) => {
             currentElements.forEach((elem) => {
                 if (!elem) return;
                 const z = elem.style.zIndex;
-                if (direction === 'FORWARD') elem.style.zIndex = `${+z + 100}`;
-                else elem.style.zIndex = `${+z - 100}`;
+                if (direction === 'FORWARD') elem.style.zIndex = `${+z + 10}`;
+                else elem.style.zIndex = `${+z - 10 < 0 ? 0 : +z - 10}`;
             });
         };
     };

--- a/client/components/Exhibition/EditorPage/EditorElement/index.tsx
+++ b/client/components/Exhibition/EditorPage/EditorElement/index.tsx
@@ -59,6 +59,7 @@ const EditorElement = ({
             backgroundColor: currentStyle.backgroundColor,
             position: 'absolute' as 'absolute',
             border: isSelected ? '1px solid #3A8FD6' : '0px',
+            zIndex: 100,
         };
     };
 


### PR DESCRIPTION
### 🔨 작업 내용 설명

1. 기존에 zIndex값 없이 element를 생성해줬음
2. 이미지 순서 변경을 위해 내리게 되면 zIndex가 -100이됨
3. 선택이 안됨

-> 
1.  element 생성시에 z-Index를 100으로 초기 설정해줌
2. 변동치는 100에서 10으로 변동
3. 만약 z-Index가 0보다 작아지려 하면 0으로 유지시켜줌

### 📑 구현한 내용 목록

- [x] zIndex 10으로 조정
- [x] element 생성시에 zIndex도 같이 생성


- close #224
