### PR TITLE
feat: Suspense & ErrorBoundary 직접 구현

### DIFF
--- a/client/components/Artwork/Tiles/index.tsx
+++ b/client/components/Artwork/Tiles/index.tsx
@@ -6,8 +6,9 @@ import ImageTile from '../ImageTile';
 import { Artwork } from 'interfaces';
 import createResource from '@utils/createResource';
 
+const resource = createResource(getAllArtworks());
+
 const Tiles = ({ align = 'center' }: { align: string }) => {
-    const resource = createResource(getAllArtworks());
     const artworks: Artwork[] = resource.read().data;
 
     return (

--- a/client/components/Artwork/Tiles/index.tsx
+++ b/client/components/Artwork/Tiles/index.tsx
@@ -4,15 +4,12 @@ import styled from '@emotion/styled';
 import { getAllArtworks } from 'service/networking';
 import ImageTile from '../ImageTile';
 import { Artwork } from 'interfaces';
+import createResource from '@utils/createResource';
+
+const resource = createResource(getAllArtworks());
 
 const Tiles = ({ align = 'center' }: { align: string }) => {
-    const [artworks, setArtworks] = useState<Artwork[]>([]);
-
-    useEffect(() => {
-        getAllArtworks().then((result) => {
-            setArtworks(result.data);
-        });
-    }, []);
+    const artworks: Artwork[] = resource.read().data;
 
     return (
         <Container align={align}>

--- a/client/components/Artwork/Tiles/index.tsx
+++ b/client/components/Artwork/Tiles/index.tsx
@@ -6,9 +6,8 @@ import ImageTile from '../ImageTile';
 import { Artwork } from 'interfaces';
 import createResource from '@utils/createResource';
 
-const resource = createResource(getAllArtworks());
-
 const Tiles = ({ align = 'center' }: { align: string }) => {
+    const resource = createResource(getAllArtworks());
     const artworks: Artwork[] = resource.read().data;
 
     return (

--- a/client/components/Exhibition/ExhbitionDetail/ExhibitionContents.tsx
+++ b/client/components/Exhibition/ExhbitionDetail/ExhibitionContents.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import { EditorElementType, EditorElementStyle } from '@components/Exhibition/EditorPage/Editor/types';
 

--- a/client/components/MyPage/ArtworkPage/index.tsx
+++ b/client/components/MyPage/ArtworkPage/index.tsx
@@ -6,6 +6,7 @@ import Filter from '../Filter';
 import BoughtArtworkPage from './BoughtArtworkPage';
 import Fallback from '@components/common/Fallback';
 import CSuspense from '@components/common/Suspense';
+import ErrorBoundary from '@components/common/ErrorBoundary';
 
 const ArtworkPage = () => {
     const [filter, setFilter] = useState<string>('등록한 작품');
@@ -18,9 +19,11 @@ const ArtworkPage = () => {
         <Container>
             <Filter filtering={filtering} current={filter} filterHandler={onClickFilter} />
             {filter === '등록한 작품' ? (
-                <Suspense fallback={<Fallback />}>
-                    <Tiles align="flex-start" />
-                </Suspense>
+                <ErrorBoundary fallback={<Fallback />}>
+                    <CSuspense fallback={<Fallback />}>
+                        <Tiles align="flex-start" />
+                    </CSuspense>
+                </ErrorBoundary>
             ) : (
                 <BoughtArtworkPage />
             )}

--- a/client/components/MyPage/ArtworkPage/index.tsx
+++ b/client/components/MyPage/ArtworkPage/index.tsx
@@ -19,7 +19,7 @@ const ArtworkPage = () => {
         <Container>
             <Filter filtering={filtering} current={filter} filterHandler={onClickFilter} />
             {filter === '등록한 작품' ? (
-                <ErrorBoundary fallback={<Fallback />}>
+                <ErrorBoundary fallback={<div>....failed</div>}>
                     <CSuspense fallback={<Fallback />}>
                         <Tiles align="flex-start" />
                     </CSuspense>

--- a/client/components/MyPage/ArtworkPage/index.tsx
+++ b/client/components/MyPage/ArtworkPage/index.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import styled from '@emotion/styled';
 
 import Tiles from '@components/Artwork/Tiles';
 import Filter from '../Filter';
 import BoughtArtworkPage from './BoughtArtworkPage';
+import Fallback from '@components/common/Fallback';
+import CSuspense from '@components/common/Suspense';
 
 const ArtworkPage = () => {
     const [filter, setFilter] = useState<string>('등록한 작품');
@@ -15,7 +17,13 @@ const ArtworkPage = () => {
     return (
         <Container>
             <Filter filtering={filtering} current={filter} filterHandler={onClickFilter} />
-            {filter === '등록한 작품' ? <Tiles align="flex-start" /> : <BoughtArtworkPage />}
+            {filter === '등록한 작품' ? (
+                <Suspense fallback={<Fallback />}>
+                    <Tiles align="flex-start" />
+                </Suspense>
+            ) : (
+                <BoughtArtworkPage />
+            )}
         </Container>
     );
 };

--- a/client/components/MyPage/Filter/index.tsx
+++ b/client/components/MyPage/Filter/index.tsx
@@ -16,9 +16,9 @@ const Filter = ({ filtering, current, filterHandler }: IFilter) => {
 
     return (
         <Container>
-            {filtering.map((item) => {
+            {filtering.map((item, idx) => {
                 return (
-                    <Item onClick={onClickItem(item)} active={current === item}>
+                    <Item onClick={onClickItem(item)} active={current === item} key={idx}>
                         {item}
                     </Item>
                 );

--- a/client/components/MyPage/ProfilePage/index.tsx
+++ b/client/components/MyPage/ProfilePage/index.tsx
@@ -18,13 +18,6 @@ const ProfilePage = ({ user }: IPRofilePage) => {
     const [toast, setToast] = useToastState();
     const { profile, nickname, socialId, description } = profileInput;
 
-    const onClickGenerateWallet = async () => {
-        if (!window.ethereum) return;
-        const web3 = new Web3(new Web3.providers.HttpProvider(ETHEREUM_HOST!));
-        const account = web3.eth.accounts.create();
-        const accounts = await web3.eth.personal.getAccounts();
-    };
-
     const onClickLogout = async () => {
         const res = await signOut(`${user.id}`);
         if (onResponseSuccess(res.status)) {
@@ -90,7 +83,6 @@ const ProfilePage = ({ user }: IPRofilePage) => {
                 </div>
             </Form>
             <ButtonContainer>
-                <BlackButton onClick={onClickGenerateWallet}>New Wallet</BlackButton>
                 <BlackButton onClick={onClickLogout}>Log out</BlackButton>
                 <BlackButton onClick={onClickSave}>Save</BlackButton>
             </ButtonContainer>

--- a/client/components/common/ErrorBoundary.tsx
+++ b/client/components/common/ErrorBoundary.tsx
@@ -17,9 +17,8 @@ export class ErrorBoundary extends Component<Prop, State> {
         error: false,
     };
 
-    componentDidCatch() {
-        console.log('error!');
-        this.setState({ error: true });
+    static getDerivedStateFromError() {
+        return { error: true };
     }
 
     render() {

--- a/client/components/common/ErrorBoundary.tsx
+++ b/client/components/common/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+
+interface Prop {
+    fallback: React.ReactChild;
+}
+
+interface State {
+    error: boolean;
+}
+
+export class ErrorBoundary extends Component<Prop, State> {
+    constructor(props: Prop) {
+        super(props);
+    }
+
+    state = {
+        error: false,
+    };
+
+    componentDidCatch() {
+        console.log('error!');
+        this.setState({ error: true });
+    }
+
+    render() {
+        if (this.state.error) {
+            return this.props.fallback;
+        }
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/client/components/common/ErrorBoundary.tsx
+++ b/client/components/common/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 interface Prop {
-    fallback: React.ReactChild;
+    fallback: React.ReactNode;
 }
 
 interface State {

--- a/client/components/common/Fallback.tsx
+++ b/client/components/common/Fallback.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Fallback = () => {
+    return <div>...loading</div>;
+};
+
+export default Fallback;

--- a/client/components/common/Suspense.tsx
+++ b/client/components/common/Suspense.tsx
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+
+interface SuspenseProps {
+    fallback: React.ReactNode;
+}
+
+interface SuspenseState {
+    pending: boolean;
+    error?: any;
+}
+
+function isPromise(i: any): i is Promise<any> {
+    return i && typeof i.then === 'function';
+}
+
+class CSuspense extends Component<SuspenseProps, SuspenseState> {
+    private mounted = false;
+
+    state: SuspenseState = {
+        pending: false,
+    };
+
+    public componentDidMount() {
+        this.mounted = true;
+    }
+
+    public componentWillUnmount() {
+        this.mounted = false;
+    }
+
+    public componentDidCatch(err: any) {
+        console.log('componentDidCatch', isPromise(err));
+        if (!this.mounted) return;
+        if (isPromise(err)) {
+            this.setState({ pending: true });
+            err.then(() => {
+                this.setState({ pending: false });
+            }).catch((err) => {
+                this.setState({ error: err || new Error('Suspense Error') });
+            });
+        } else {
+            throw err;
+        }
+    }
+
+    public componentDidUpdate() {
+        if (this.state.pending && this.state.error) {
+            throw this.state.error;
+        }
+    }
+
+    public render() {
+        console.log(this.state.pending);
+        return this.state.pending ? this.props.fallback : this.props.children;
+    }
+}
+
+export default CSuspense;

--- a/client/components/common/Suspense.tsx
+++ b/client/components/common/Suspense.tsx
@@ -14,32 +14,31 @@ function isPromise(i: any): i is Promise<any> {
 }
 
 class CSuspense extends Component<SuspenseProps, SuspenseState> {
-    private mounted = false;
-
     state: SuspenseState = {
         pending: false,
     };
 
-    public componentDidMount() {
-        this.mounted = true;
+    constructor(props: SuspenseProps) {
+        super(props);
     }
 
-    public componentWillUnmount() {
-        this.mounted = false;
+    static getDerivedStateFromError(err: any) {
+        if (isPromise(err)) {
+            console.log(err);
+            return { pending: false };
+        }
+        return { pending: true };
     }
 
     public componentDidCatch(err: any) {
-        console.log('componentDidCatch', isPromise(err));
-        if (!this.mounted) return;
         if (isPromise(err)) {
+            console.log(err);
             this.setState({ pending: true });
             err.then(() => {
                 this.setState({ pending: false });
             }).catch((err) => {
                 this.setState({ error: err || new Error('Suspense Error') });
             });
-        } else {
-            throw err;
         }
     }
 
@@ -50,8 +49,11 @@ class CSuspense extends Component<SuspenseProps, SuspenseState> {
     }
 
     public render() {
-        console.log(this.state.pending);
-        return this.state.pending ? this.props.fallback : this.props.children;
+        console.log('pending : ', this.state.pending);
+        if (this.state.pending) {
+            return this.props.fallback;
+        }
+        return this.props.children;
     }
 }
 

--- a/client/utils/createResource.ts
+++ b/client/utils/createResource.ts
@@ -1,0 +1,34 @@
+const createResource = (promise: Promise<any>) => {
+    return wrapPromise(promise);
+};
+
+const wrapPromise = <T>(promise: Promise<T>) => {
+    let status = 'pending';
+    let result: T | null;
+
+    let suspender = promise.then(
+        (response) => {
+            status = 'success';
+            result = response;
+        },
+        (error) => {
+            status = 'error';
+            result = error;
+        },
+    );
+
+    return {
+        read() {
+            switch (status) {
+                case 'pending':
+                    throw suspender;
+                case 'error':
+                    throw result;
+                default:
+                    return result;
+            }
+        },
+    };
+};
+
+export default createResource;

--- a/client/utils/createResource.ts
+++ b/client/utils/createResource.ts
@@ -17,7 +17,7 @@ const createResource = (promise: Promise<any>) => {
         read() {
             switch (status) {
                 case 'pending':
-                    throw suspender;
+                    throw { suspender, status };
                 case 'error':
                     throw result;
                 default:

--- a/client/utils/createResource.ts
+++ b/client/utils/createResource.ts
@@ -1,10 +1,6 @@
 const createResource = (promise: Promise<any>) => {
-    return wrapPromise(promise);
-};
-
-const wrapPromise = <T>(promise: Promise<T>) => {
     let status = 'pending';
-    let result: T | null;
+    let result: any;
 
     let suspender = promise.then(
         (response) => {


### PR DESCRIPTION
### 🔨 작업 내용 설명

리액트 18버전에서 추가될 `Suspense`, `ErrorBoundary` 직접 구현 및 적용.
어떤 비동기 작업인지를 Suspense가 알아야 하고, Promise 상태를 알아야 fallback / 자식 컴포넌트 렌더링을 결정할 수 있기 때문에 `createResource` 함수도 같이 구현.

### 📑 구현한 내용 목록

- [x] createResource() 구현
- [x] ErrorBoundary 구현
- [x] Suspense 구현

### 🚧 주의 사항

(tsconfig.json에 `incremental : true` 옵션을 넣었는데 이거때문에 되는건지는 잘 모르겠음.)

성공했을때의 컴포넌트(원본) 안에서 `createResource()` 함수에 axios를 이용한 api 요청 함수를 집어넣고
Suspense로 감싸면 됩니다.

### 🖥 스크린 샷

![스크린샷 2021-11-25 오전 4 05 03](https://user-images.githubusercontent.com/53335940/143299083-eda2d238-5eff-453e-8975-15d0f2a62d81.png)

![스크린샷 2021-11-25 오전 4 06 18](https://user-images.githubusercontent.com/53335940/143299268-f94b569c-325e-4558-9acd-ff3db20abaaa.png)

![무제](https://user-images.githubusercontent.com/53335940/143299325-e060afda-a88b-497c-b04b-e66e26030221.gif)


- close #232 
