### PR TITLE
Fix/#259 buglist2

### DIFF
--- a/client/components/Artwork/ArtworkModal/index.tsx
+++ b/client/components/Artwork/ArtworkModal/index.tsx
@@ -48,7 +48,7 @@ const ArtworkModal = ({ handleModalInput, position, handleModalPosition, onClick
                             type="text"
                             value={artworkInput.bidEnd}
                             onChange={onChangeBidEnd}
-                            placeholder="yyyy-mm-dd"
+                            placeholder="yyyy-mm-dd HH:MM"
                         />
                         {!validInput.bidEnd && <p>input right format</p>}
                     </LightForm>

--- a/client/components/Artwork/NewArtwork/index.tsx
+++ b/client/components/Artwork/NewArtwork/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Button } from '@styles/common';
 import ArtworkModal from '../ArtworkModal';
@@ -16,6 +16,10 @@ const NewArtwork = ({ image }: NewArtworkProp) => {
         useInputArtwork(image);
     const { backgroundImageRef, imageRef } = usePreviewImage(image);
     const { modalPositionTop, handleModalPosition, onClickHiddenModal } = useControlModalPosition();
+
+    const onKeyDownTab = (e: React.KeyboardEvent) => {
+        if (e.key === 'Tab') e.preventDefault();
+    };
 
     return (
         <>
@@ -44,6 +48,7 @@ const NewArtwork = ({ image }: NewArtworkProp) => {
                             placeholder="ex) Photography ..."
                             value={typeInput}
                             onChange={onChangeTypeInput}
+                            onKeyDown={onKeyDownTab}
                         />
                     </Input>
                 </Form>

--- a/client/components/Artwork/ResultDetail/index.tsx
+++ b/client/components/Artwork/ResultDetail/index.tsx
@@ -38,6 +38,10 @@ const Container = styled.div`
     overflow-y: scroll;
     height: 100%;
     padding: 5%;
+
+    ::-webkit-scrollbar {
+        display: none;
+    }
 `;
 
 const Box = styled.section`

--- a/client/components/Artwork/Uploader/index.tsx
+++ b/client/components/Artwork/Uploader/index.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import CSuspense from '@components/common/Suspense';
 import Fallback from '@components/common/Fallback';
 import useToast from '@hooks/useToast';
+import ErrorBoundary from '@components/common/ErrorBoundary';
 
 const Tiles = dynamic(() => import('@components/Artwork/Tiles'), { ssr: false });
 
@@ -42,9 +43,11 @@ const Uploader = ({ handleNewImage }: UploaderProps) => {
                 <input type="file" name="newArtwork" ref={inputRef} onChange={onChangeFile} />
                 <img src="/icons/add.png" alt="add" />
             </FileInput>
-            <CSuspense fallback={<Fallback />}>
-                <Tiles align="center" />
-            </CSuspense>
+            <ErrorBoundary fallback={<div>...failed</div>}>
+                <CSuspense fallback={<Fallback />}>
+                    <Tiles align="center" />
+                </CSuspense>
+            </ErrorBoundary>
         </Container>
     );
 };

--- a/client/components/Auction/ItemDetail/index.tsx
+++ b/client/components/Auction/ItemDetail/index.tsx
@@ -1,13 +1,14 @@
 import React, { useContext, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
 
 import AboutArtist from '../AboutArtist';
-import BidTable from '../BidTable';
 import Trend from '../Trend';
 import ArtworkDetail from '../ArtworkDetail';
 import { Auction } from 'interfaces';
 import useAuctionSocketState from '@store/auctionSocketState';
 import { setColorFromImage } from '@utils/setColorFromImage';
+const BidTable = dynamic(() => import('../BidTable'), { ssr: false });
 
 export type trendHistory = {
     bidder: {
@@ -55,14 +56,10 @@ const Container = styled.section`
     overflow-y: scroll;
     overflow-x: hidden;
     padding: 10px 0;
+    position: relative;
 
     &::-webkit-scrollbar {
-        width: 8px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background: #bbbbbb;
-        border-radius: 10px;
+        display: none;
     }
 
     & > div {

--- a/client/components/Auction/ItemDetail/index.tsx
+++ b/client/components/Auction/ItemDetail/index.tsx
@@ -7,6 +7,7 @@ import Trend from '../Trend';
 import ArtworkDetail from '../ArtworkDetail';
 import { Auction } from 'interfaces';
 import useAuctionSocketState from '@store/auctionSocketState';
+import { setColorFromImage } from '@utils/setColorFromImage';
 
 export type trendHistory = {
     bidder: {
@@ -16,8 +17,9 @@ export type trendHistory = {
     biddedAt: string;
 };
 
-const ItemDetail = ({ auction }: { auction: Auction }) => {
+const ItemDetail = ({ auction, image }: { auction: Auction; image: string }) => {
     const [socket] = useAuctionSocketState();
+    const [isBlack, setIsBlack] = useState(true);
 
     const { id, artwork, artist, auctionHistories, price } = auction;
     const { title, type } = artwork;
@@ -27,6 +29,7 @@ const ItemDetail = ({ auction }: { auction: Auction }) => {
 
     useEffect(() => {
         socket.emit('@auction/enter', id);
+        setColorFromImage(image).then((res) => setIsBlack(res));
 
         return () => {
             socket.emit('@auction/leave', id);
@@ -35,7 +38,7 @@ const ItemDetail = ({ auction }: { auction: Auction }) => {
 
     return (
         <Container>
-            <Summary>
+            <Summary isBlack={isBlack}>
                 <h1>{title}</h1>
                 <span>{type}</span>
             </Summary>
@@ -73,7 +76,7 @@ const Container = styled.section`
     }
 `;
 
-const Summary = styled.section`
+const Summary = styled.section<{ isBlack: boolean }>`
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -82,6 +85,7 @@ const Summary = styled.section`
     & > span,
     h1 {
         margin: 2px;
+        color: ${({ isBlack }) => (isBlack ? 'black' : 'white')};
     }
 
     & > h1 {

--- a/client/components/Exhibition/ArtworkSelectorWrapper/index.tsx
+++ b/client/components/Exhibition/ArtworkSelectorWrapper/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { SpaceBetween } from '@styles/common';
 import CSuspense from '@components/common/Suspense';
+import ErrorBoundary from '@components/common/ErrorBoundary';
 import Fallback from '@components/common/Fallback';
 const ArtworkSelector = dynamic(() => import('@components/Exhibition/ArtworkSelector'), { ssr: false });
 
@@ -13,9 +14,11 @@ const index = () => {
             <ArtworkSelectorHeader>
                 <Label>작품 선택하기</Label>
             </ArtworkSelectorHeader>
-            <CSuspense fallback={<Fallback />}>
-                <ArtworkSelector />
-            </CSuspense>
+            <ErrorBoundary fallback={<div>...failed</div>}>
+                <CSuspense fallback={<Fallback />}>
+                    <ArtworkSelector />
+                </CSuspense>
+            </ErrorBoundary>
         </ArtworkSelectorWrapper>
     );
 };

--- a/client/components/Header/headerStyles.tsx
+++ b/client/components/Header/headerStyles.tsx
@@ -15,7 +15,7 @@ const routeMyPageOrLogin = (session: any) => {
     };
 };
 
-export const defaultHeader = (session: any) => {
+const DefaultHeader = ({ session }: { session: any }) => {
     return (
         <RightContainer>
             <Link href="/exhibition">
@@ -30,3 +30,5 @@ export const defaultHeader = (session: any) => {
         </RightContainer>
     );
 };
+
+export default DefaultHeader;

--- a/client/components/Header/index.tsx
+++ b/client/components/Header/index.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/router';
 
 import Logo from '@assets/images/logo.png';
 import { HeaderContainer, LeftContainer, Hr, ImageContainer } from './style';
-import { defaultHeader } from './headerStyles';
 import useSessionState from '@store/sessionState';
+import dynamic from 'next/dynamic';
+const DefaultHeader = dynamic(() => import('./headerStyles'), { ssr: false });
 
 const pathToObj = {
     '': { title: 'Main', root: '/' },
@@ -32,7 +33,7 @@ const Header = () => {
                 <Hr />
                 <Link href={pathToObj[mainPath].root}>{pathToObj[mainPath].title}</Link>
             </LeftContainer>
-            {defaultHeader(session)}
+            {<DefaultHeader session={session} />}
         </HeaderContainer>
     );
 };

--- a/client/hooks/useArtworkInput.ts
+++ b/client/hooks/useArtworkInput.ts
@@ -49,7 +49,7 @@ const useArtworkInput = () => {
 
     const onChangeBidEnd = (e: React.FormEvent) => {
         const input = (e.target as HTMLInputElement).value;
-        const regex = RegExp(/^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/gi);
+        const regex = RegExp(/^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]) [01][\d]:[0-5][\d]$/gi);
         if (!regex.test(input) && input.length > 0) setValidInput({ ...validInput, bidEnd: false });
         else setValidInput({ ...validInput, bidEnd: true });
         setArtworkInput({ ...artworkInput, bidEnd: input });

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,9 @@
             "name": "client",
             "version": "0.1.0",
             "dependencies": {
+                "@emotion/css": "^11.5.0",
                 "@emotion/react": "^11.5.0",
+                "@emotion/server": "^11.4.0",
                 "@emotion/styled": "^11.3.0",
                 "@next/bundle-analyzer": "^12.0.1",
                 "@types/react-slick": "^0.23.7",
@@ -211,6 +213,26 @@
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
             "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
         },
+        "node_modules/@emotion/css": {
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.5.0.tgz",
+            "integrity": "sha512-mqjz/3aqR9rp40M+pvwdKYWxlQK4Nj3cnNjo3Tx6SM14dSsEn7q/4W2/I7PlgG+mb27iITHugXuBIHH/QwUBVQ==",
+            "dependencies": {
+                "@emotion/babel-plugin": "^11.0.0",
+                "@emotion/cache": "^11.5.0",
+                "@emotion/serialize": "^1.0.0",
+                "@emotion/sheet": "^1.0.3",
+                "@emotion/utils": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@emotion/hash": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -265,6 +287,25 @@
                 "@emotion/unitless": "^0.7.5",
                 "@emotion/utils": "^1.0.0",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/server": {
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.4.0.tgz",
+            "integrity": "sha512-IHovdWA3V0DokzxLtUNDx4+hQI82zUXqQFcVz/om2t44O0YSc+NHB+qifnyAOoQwt3SXcBTgaSntobwUI9gnfA==",
+            "dependencies": {
+                "@emotion/utils": "^1.0.0",
+                "html-tokenize": "^2.0.0",
+                "multipipe": "^1.0.2",
+                "through": "^2.3.8"
+            },
+            "peerDependencies": {
+                "@emotion/css": "^11.0.0-rc.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/css": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@emotion/sheet": {
@@ -2024,6 +2065,11 @@
                 "ieee754": "^1.1.4"
             }
         },
+        "node_modules/buffer-from": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+            "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
         "node_modules/buffer-to-arraybuffer": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -2688,6 +2734,41 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/duplexer2/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/duplexer2/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/duplexer2/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
         },
         "node_modules/duplexer3": {
             "version": "0.1.4",
@@ -4455,6 +4536,42 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
+        "node_modules/html-tokenize": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+            "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+            "dependencies": {
+                "buffer-from": "~0.1.1",
+                "inherits": "~2.0.1",
+                "minimist": "~1.2.5",
+                "readable-stream": "~1.0.27-1",
+                "through2": "~0.4.1"
+            },
+            "bin": {
+                "html-tokenize": "bin/cmd.js"
+            }
+        },
+        "node_modules/html-tokenize/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "node_modules/html-tokenize/node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/html-tokenize/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
         "node_modules/http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -5512,6 +5629,15 @@
             "dependencies": {
                 "base-x": "^3.0.8",
                 "buffer": "^5.5.0"
+            }
+        },
+        "node_modules/multipipe": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+            "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+            "dependencies": {
+                "duplexer2": "^0.1.2",
+                "object-assign": "^4.1.0"
             }
         },
         "node_modules/nano-json-stream-parser": {
@@ -7655,6 +7781,57 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "node_modules/through2": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+            "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+            "dependencies": {
+                "readable-stream": "~1.0.17",
+                "xtend": "~2.1.1"
+            }
+        },
+        "node_modules/through2/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "node_modules/through2/node_modules/object-keys": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+            "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "node_modules/through2/node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/through2/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "node_modules/through2/node_modules/xtend": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+            "dependencies": {
+                "object-keys": "~0.4.0"
+            },
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/timed-out": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -8899,6 +9076,18 @@
                 }
             }
         },
+        "@emotion/css": {
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.5.0.tgz",
+            "integrity": "sha512-mqjz/3aqR9rp40M+pvwdKYWxlQK4Nj3cnNjo3Tx6SM14dSsEn7q/4W2/I7PlgG+mb27iITHugXuBIHH/QwUBVQ==",
+            "requires": {
+                "@emotion/babel-plugin": "^11.0.0",
+                "@emotion/cache": "^11.5.0",
+                "@emotion/serialize": "^1.0.0",
+                "@emotion/sheet": "^1.0.3",
+                "@emotion/utils": "^1.0.0"
+            }
+        },
         "@emotion/hash": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -8941,6 +9130,17 @@
                 "@emotion/unitless": "^0.7.5",
                 "@emotion/utils": "^1.0.0",
                 "csstype": "^3.0.2"
+            }
+        },
+        "@emotion/server": {
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.4.0.tgz",
+            "integrity": "sha512-IHovdWA3V0DokzxLtUNDx4+hQI82zUXqQFcVz/om2t44O0YSc+NHB+qifnyAOoQwt3SXcBTgaSntobwUI9gnfA==",
+            "requires": {
+                "@emotion/utils": "^1.0.0",
+                "html-tokenize": "^2.0.0",
+                "multipipe": "^1.0.2",
+                "through": "^2.3.8"
             }
         },
         "@emotion/sheet": {
@@ -10222,6 +10422,11 @@
                 "ieee754": "^1.1.4"
             }
         },
+        "buffer-from": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+            "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
         "buffer-to-arraybuffer": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -10773,6 +10978,43 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
         },
         "duplexer3": {
             "version": "0.1.4",
@@ -12173,6 +12415,41 @@
                 }
             }
         },
+        "html-tokenize": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+            "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+            "requires": {
+                "buffer-from": "~0.1.1",
+                "inherits": "~2.0.1",
+                "minimist": "~1.2.5",
+                "readable-stream": "~1.0.27-1",
+                "through2": "~0.4.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
         "http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -12974,6 +13251,15 @@
                         "buffer": "^5.5.0"
                     }
                 }
+            }
+        },
+        "multipipe": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+            "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+            "requires": {
+                "duplexer2": "^0.1.2",
+                "object-assign": "^4.1.0"
             }
         },
         "nano-json-stream-parser": {
@@ -14615,6 +14901,56 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+            "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+            "requires": {
+                "readable-stream": "~1.0.17",
+                "xtend": "~2.1.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "object-keys": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                    "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "xtend": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                    "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+                    "requires": {
+                        "object-keys": "~0.4.0"
+                    }
+                }
+            }
         },
         "timed-out": {
             "version": "4.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "@emotion/css": "^11.5.0",
         "@emotion/react": "^11.5.0",
+        "@emotion/server": "^11.4.0",
         "@emotion/styled": "^11.3.0",
         "@next/bundle-analyzer": "^12.0.1",
         "@types/react-slick": "^0.23.7",

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -1,6 +1,31 @@
-import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript, DocumentContext, DocumentInitialProps } from 'next/document';
+import createEmotionServer from '@emotion/server/create-instance';
+import { cache } from '@emotion/css';
+
+const renderStatic = async (html: any) => {
+    if (!html) throw new Error('Must retrn html from renderToString');
+    const { extractCritical } = createEmotionServer(cache);
+    const { ids, css } = extractCritical(html);
+
+    return { html, ids, css };
+};
 
 export default class MyDocument extends Document {
+    static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+        const page = await ctx.renderPage();
+        const { css, ids } = await renderStatic(page.html);
+        const initialProps = await Document.getInitialProps(ctx);
+        return {
+            ...initialProps,
+            styles: (
+                <>
+                    {initialProps.styles}
+                    <style data-emotion={`css ${ids.join('  ')}`} dangerouslySetInnerHTML={{ __html: css }} />
+                </>
+            ),
+        };
+    }
+
     render() {
         return (
             <Html>

--- a/client/pages/auction/[id].tsx
+++ b/client/pages/auction/[id].tsx
@@ -22,7 +22,7 @@ const AuctionDetailPage = ({ auction }: { auction: Auction }) => {
                 <title>
                     Auction - {title} ({name}, {year})
                 </title>
-                <meta name="경매" content="경매경매" />
+                <meta name={title} content={`(${name}, ${year})`} />
             </Head>
             <Layout>
                 <Container>
@@ -40,7 +40,7 @@ const AuctionDetailPage = ({ auction }: { auction: Auction }) => {
                                 <span>click image to zoom</span>
                             </ImageWrapper>
                         </section>
-                        <ItemDetail auction={auction} />
+                        <ItemDetail auction={auction} image={originalImage} />
                     </Grid>
                 </Container>
             </Layout>

--- a/client/pages/exhibition/[id].tsx
+++ b/client/pages/exhibition/[id].tsx
@@ -6,6 +6,8 @@ import Layout from '@components/common/Layout';
 import ExhibitionDetail from '@components/Exhibition/ExhbitionDetail';
 import { getExhibition } from '@service/networking';
 import { Exhibition } from 'interfaces';
+import ErrorBoundary from '@components/common/ErrorBoundary';
+import Fallback from '@components/common/Fallback';
 
 const ExhibitionDetailPage = ({ exhibition }: { exhibition: Exhibition }) => {
     return (
@@ -13,7 +15,11 @@ const ExhibitionDetailPage = ({ exhibition }: { exhibition: Exhibition }) => {
             <Head>
                 <title>벽전 - 전시회 탐색</title>
             </Head>
-            <Layout>{exhibition && <ExhibitionDetail exhibition={exhibition} />}</Layout>
+            <Layout>
+                <ErrorBoundary fallback={<Fallback />}>
+                    <ExhibitionDetail exhibition={exhibition} />
+                </ErrorBoundary>
+            </Layout>
         </div>
     );
 };

--- a/client/pages/exhibition/post.tsx
+++ b/client/pages/exhibition/post.tsx
@@ -11,6 +11,9 @@ import useInputExhibition from '@hooks/useInputExhibition';
 import { EditorElementProp } from '@components/Exhibition/EditorPage/Editor/types';
 import { useEditorImageState, useSelectedImageState } from '@store/editorImageState';
 import useToast from '@hooks/useToast';
+import CSuspense from '@components/common/Suspense';
+import Fallback from '@components/common/Fallback';
+import ErrorBoundary from '@components/common/ErrorBoundary';
 
 const ExhibitionPostPage = () => {
     const [currentPage, setCurrentPage] = useState<'FORM' | 'EDITOR'>('FORM');
@@ -31,7 +34,7 @@ const ExhibitionPostPage = () => {
 
     const onClickNextButton = () => {
         const { title, startAt, endAt, thumbnail } = formInput;
-        if(!title || !startAt || !endAt || !thumbnail || !selectedImages.length) {
+        if (!title || !startAt || !endAt || !thumbnail || !selectedImages.length) {
             showToast('failed');
             return;
         }
@@ -44,10 +47,10 @@ const ExhibitionPostPage = () => {
     };
 
     useEffect(() => {
-        return (() => {
+        return () => {
             setSelectedImages([]);
             setEditorImageState([]);
-        });
+        };
     }, []);
 
     return (
@@ -64,7 +67,11 @@ const ExhibitionPostPage = () => {
                         </Title>
                         <Container>
                             <Form formInput={formInput} />
-                            <ArtworkSelector />
+                            <ErrorBoundary fallback={<div>...failed</div>}>
+                                <CSuspense fallback={<Fallback />}>
+                                    <ArtworkSelector />
+                                </CSuspense>
+                            </ErrorBoundary>
                             <NextButton onClick={onClickNextButton}>Next</NextButton>
                         </Container>
                     </>


### PR DESCRIPTION
### 🔨 작업 내용 설명

자꾸 에러나던것중에 css 관련된 내용도 있는것같아서 css 프리로딩 코드를 추가했습니다.
_document 내부에서 getInitialProps 함수를 만들어 써먹었고, html을 파싱해서 head 안에 style 태그를 서버사이드에서 만들어줍니다.
경매 상세 페이지가 터지는 문제는 ReactDOMServer와 쓰지도 않는 Suspense 얘기가 나와서 문제가 있던 컴포넌트를 동적으로 import해서 해결했습니다.
작품 추가 페이지 tab 막는 작업은 type 입력칸에서 tab 입력 시에만 먹도록 했습니다.

### 📑 구현한 내용 목록

- [x] 경매 상세페이지 터지는거 고치기
- [x] css 프리로딩
- [x] 전시회 상세페이지 새로고침 시 console.log와 warning 나오는거 해결
- [x] 옥션 상세페이지 제목 색 적응형으로 바꾸기
- [x] 작품 추가 페이지 tab 막기

### 🚧 주의 사항

기능을 구현하면서 만났던 어려웠던 점.

### 🖥 스크린 샷

![화면 기록 2021-11-30 오후 5 21 11](https://user-images.githubusercontent.com/53335940/144010963-bc2a084a-54f7-493c-a4a1-c63370ba1df6.gif)


- close #260 
